### PR TITLE
Guard main merges behind dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,20 @@ permissions:
   contents: read
 
 jobs:
+  main-merge-guard:
+    name: Main merge guard
+    if: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Allow only dev into main
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.head_ref }}" != "dev" ]]; then
+            echo "::error::Pull requests targeting main must come from dev. Current source branch: ${{ github.head_ref }}"
+            exit 1
+          fi
+
   quality-gates:
     uses: ./.github/workflows/_quality-gates.yml

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -135,7 +135,8 @@ Configure les branch rules GitHub :
 2. `main`
    - PR obligatoire
    - status checks obligatoires sur la CI
-   - merge uniquement depuis `dev`
+   - status check `Main merge guard` obligatoire
+   - seules les PR `dev -> main` peuvent passer la CI
    - approbation requise avant merge
 
 ## URLs generees


### PR DESCRIPTION
## What changed
- added a `Main merge guard` job in CI
- this job runs on pull requests targeting `main`
- it fails unless the source branch is exactly `dev`
- updated deployment documentation to reflect the new protection rule

## Why
The deployment flow is now based on `feature -> dev -> main`.
To enforce that in GitHub itself, merges into `main` must be blocked unless they come from `dev`.

## Expected protection after merge
- direct pushes to `main` remain blocked by branch protection
- pull requests into `main` from feature branches fail on `Main merge guard`
- only `dev -> main` can satisfy the required checks
