### PR TITLE
Sync main into dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,5 +14,20 @@ permissions:
   contents: read
 
 jobs:
+  main-merge-guard:
+    name: Main merge guard
+    if: ${{ github.event_name == 'pull_request' && github.base_ref == 'main' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Allow only dev into main
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.head_ref }}" != "dev" ]]; then
+            echo "::error::Pull requests targeting main must come from dev. Current source branch: ${{ github.head_ref }}"
+            exit 1
+          fi
+
   quality-gates:
     uses: ./.github/workflows/_quality-gates.yml

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -135,7 +135,8 @@ Configure les branch rules GitHub :
 2. `main`
    - PR obligatoire
    - status checks obligatoires sur la CI
-   - merge uniquement depuis `dev`
+   - status check `Main merge guard` obligatoire
+   - seules les PR `dev -> main` peuvent passer la CI
    - approbation requise avant merge
 
 ## URLs generees


### PR DESCRIPTION
## Why
`main` is one commit ahead of `dev` after the merge of the main branch guard.

As of April 2, 2026:
- `main` is on `dc253e6a1be0391c173420898d2887d37acf27fc`
- `dev` is on `614a16c2a2cf1765761a0a1d99b972da124c1be3`

This PR syncs the `Main merge guard` change back into `dev` so future feature work starts from the same CI/CD baseline.

## Expected result after merge
- `dev` and `main` are aligned on branch governance
- future PRs to `dev` keep the same CI logic as production
- the next test deployment still targets `dofus-like-test`
