### PR TITLE
fix(web): nginx cache headers — index.html no-cache, assets immutable

### DIFF
--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -4,6 +4,28 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # index.html must never be cached: it references hashed asset filenames.
+    # Without this, browsers serve stale HTML after a deploy and users never see updates.
+    location = /index.html {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        add_header Expires "0";
+        try_files $uri =404;
+    }
+
+    # Vite bakes a content hash into every asset filename (e.g. index.abc123.js).
+    # Cache them aggressively — they are immutable by definition.
+    location ~* \.(js|css|woff2?|ttf|eot|ico|png|jpg|jpeg|gif|svg|webp|avif)$ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
+    }
+
+    # version.txt / version.json — used by the deploy pipeline; must not be cached.
+    location ~* ^/version\.(txt|json)$ {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        try_files $uri =404;
+    }
+
     # SPA routing
     location / {
         try_files $uri $uri/ /index.html;


### PR DESCRIPTION
## Problème

Après chaque déploiement, les utilisateurs doivent faire un **hard refresh** (Cmd+Shift+R) pour voir les nouvelles fonctionnalités. Sans header `Cache-Control`, le navigateur sert le vieux `index.html` depuis son cache — les nouveaux assets Vite (JS/CSS) ne sont jamais chargés.

C'est pourquoi la pipeline passait au vert (SHA vérifié sur les containers) mais l'interface semblait ne pas changer.

## Fix

Trois règles de cache ajoutées au `nginx.conf` :

| Ressource | Header |
|---|---|
| `index.html` | `no-cache, no-store, must-revalidate` — toujours refetch |
| `*.js`, `*.css`, images, fonts | `public, max-age=31536000, immutable` — Vite hash le nom de fichier |
| `version.txt` / `version.json` | `no-cache` — utilisés par le script de déploiement |

## Test

Après merge et déploiement : ouvrir le site sans hard refresh → les changements doivent être visibles immédiatement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)