### PR TITLE
fix(seed): make seed idempotent with upsert — preserves player data o…

### DIFF
--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -303,99 +303,138 @@ async function rebuildPlayerSpellsForPlayer(playerId: string) {
 async function main() {
   console.log('🌱 Seeding database...');
 
-  // Nettoyage (ordre inverse des clés étrangères)
+  // Only clear volatile session/combat data — catalog and player data are preserved.
   await prisma.combatTurn.deleteMany();
   await prisma.combatSession.deleteMany();
   await prisma.sessionItem.deleteMany();
   await prisma.gameSession.deleteMany();
-  await prisma.playerSpell.deleteMany();
-  await prisma.itemGrantedSpell.deleteMany();
-  await prisma.equipmentSlot.deleteMany();
-  await prisma.inventoryItem.deleteMany();
-  await prisma.playerStats.deleteMany();
-  await prisma.player.deleteMany();
-  await prisma.item.deleteMany();
-  await prisma.spell.deleteMany();
 
-  // ── Sorts de base ──────────────────────────────────────────────────
+  // ── Sorts : upsert par code (idempotent) ──────────────────────────
   const spellsByCode = new Map<string, Awaited<ReturnType<typeof prisma.spell.create>>>();
-  for (const spellDefinition of SPELL_DEFINITIONS) {
-    const spell = await prisma.spell.create({
-      data: spellDefinition,
+  for (const spellDef of SPELL_DEFINITIONS) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const spell = await prisma.spell.upsert({
+      where: { code: spellDef.code },
+      create: { ...spellDef },
+      update: { ...spellDef },
     });
     spellsByCode.set(spell.code, spell);
   }
 
-  // ── Ressources ──────────────────────────────────────────────────
-
-  const fer = await prisma.item.create({
-    data: {
+  // ── Ressources : upsert par name ──────────────────────────────────
+  const fer = await prisma.item.upsert({
+    where: { name: 'Fer' },
+    create: {
       name: 'Fer',
       type: ItemType.RESOURCE,
       description:
         "Un morceau de métal qui sent le vieux clou. On raconte qu'il a été forgé avec la sueur d'un nain constipé.",
       iconPath: '/assets/items/fer.png',
     },
+    update: {
+      iconPath: '/assets/items/fer.png',
+      description:
+        "Un morceau de métal qui sent le vieux clou. On raconte qu'il a été forgé avec la sueur d'un nain constipé.",
+    },
   });
 
-  const cuir = await prisma.item.create({
-    data: {
+  const cuir = await prisma.item.upsert({
+    where: { name: 'Cuir' },
+    create: {
       name: 'Cuir',
       type: ItemType.RESOURCE,
       description:
         'Souple et résistant. Parfait pour se faire une armure ou un slip de rechange après un combat intense.',
       iconPath: '/assets/items/cuir.png',
     },
+    update: {
+      iconPath: '/assets/items/cuir.png',
+      description:
+        'Souple et résistant. Parfait pour se faire une armure ou un slip de rechange après un combat intense.',
+    },
   });
-  const cristal = await prisma.item.create({
-    data: {
+
+  const cristal = await prisma.item.upsert({
+    where: { name: 'Cristal magique' },
+    create: {
       name: 'Cristal magique',
       type: ItemType.RESOURCE,
       description:
         'Ça brille, ça coûte cher, et ça fait des étincelles quand on le frotte contre son entrejambe.',
       iconPath: '/assets/items/cristal.png',
     },
+    update: {
+      iconPath: '/assets/items/cristal.png',
+      description:
+        'Ça brille, ça coûte cher, et ça fait des étincelles quand on le frotte contre son entrejambe.',
+    },
   });
-  const etoffe = await prisma.item.create({
-    data: {
+
+  const etoffe = await prisma.item.upsert({
+    where: { name: 'Étoffe' },
+    create: {
       name: 'Étoffe',
       type: ItemType.RESOURCE,
       description:
         "Tissu de haute qualité. Idéal pour les mages qui veulent avoir l'air mystérieux sans avoir froid aux fesses.",
       iconPath: '/assets/items/etoffe.png',
     },
-  });
-  const bois = await prisma.item.create({
-    data: {
-      name: 'Bois',
-      type: ItemType.RESOURCE,
+    update: {
+      iconPath: '/assets/items/etoffe.png',
       description:
-        'Robuste et fibreux. Pourrait servir de gourdin si vous étiez un peu plus barbare.',
-      iconPath: '/assets/items/bois.png',
+        "Tissu de haute qualité. Idéal pour les mages qui veulent avoir l'air mystérieux sans avoir froid aux fesses.",
     },
   });
-  const herbe = await prisma.item.create({
-    data: {
+
+  const bois = await prisma.item.upsert({
+    where: { name: 'Bois' },
+    create: {
+      name: 'Bois',
+      type: ItemType.RESOURCE,
+      description: 'Robuste et fibreux. Pourrait servir de gourdin si vous étiez un peu plus barbare.',
+      iconPath: '/assets/items/bois.png',
+    },
+    update: {
+      iconPath: '/assets/items/bois.png',
+      description: 'Robuste et fibreux. Pourrait servir de gourdin si vous étiez un peu plus barbare.',
+    },
+  });
+
+  const herbe = await prisma.item.upsert({
+    where: { name: 'Herbe médicinale' },
+    create: {
       name: 'Herbe médicinale',
       type: ItemType.RESOURCE,
       description: 'Ça soigne les plaies, mais ça donne aussi une haleine de poney mort.',
       iconPath: '/assets/items/herbe.png',
     },
+    update: {
+      iconPath: '/assets/items/herbe.png',
+      description: 'Ça soigne les plaies, mais ça donne aussi une haleine de poney mort.',
+    },
   });
-  const or = await prisma.item.create({
-    data: {
+
+  const or = await prisma.item.upsert({
+    where: { name: 'Or' },
+    create: {
       name: 'Or',
       type: ItemType.RESOURCE,
       description:
         "Le nerf de la guerre. Et l'ami des gens qui n'ont rien d'autre à offrir que leur portefeuille.",
       iconPath: '/assets/items/or.png',
     },
+    update: {
+      iconPath: '/assets/items/or.png',
+      description:
+        "Le nerf de la guerre. Et l'ami des gens qui n'ont rien d'autre à offrir que leur portefeuille.",
+    },
   });
 
-  // ── Armes : boutique 25 Po (max 2 pièces d’équipement par victoire à +50 Po) ──
+  // ── Armes ─────────────────────────────────────────────────────────
 
-  const epee = await prisma.item.create({
-    data: {
+  const epee = await prisma.item.upsert({
+    where: { name: 'Épée' },
+    create: {
       name: 'Épée',
       type: ItemType.WEAPON,
       description:
@@ -405,10 +444,19 @@ async function main() {
       shopPrice: 50,
       iconPath: '/assets/items/epee.png',
     },
+    update: {
+      iconPath: '/assets/items/epee.png',
+      shopPrice: 50,
+      statsBonus: { atk: 5 },
+      craftCost: { [fer.id]: 2, [cuir.id]: 1 },
+      description:
+        'Tranchante, mais surtout utile pour couper le saucisson... ou les doigts des imprudents.',
+    },
   });
 
-  const bouclier = await prisma.item.create({
-    data: {
+  const bouclier = await prisma.item.upsert({
+    where: { name: 'Bouclier' },
+    create: {
       name: 'Bouclier',
       type: ItemType.WEAPON,
       description:
@@ -418,10 +466,19 @@ async function main() {
       shopPrice: 50,
       iconPath: '/assets/items/bouclier.png',
     },
+    update: {
+      iconPath: '/assets/items/bouclier.png',
+      shopPrice: 50,
+      statsBonus: { def: 5 },
+      craftCost: { [fer.id]: 1, [cuir.id]: 2 },
+      description:
+        "Plus efficace qu'une planche en bois, mais moins qu'un mur en briques. Protège le devant, le reste est à vos risques et périls.",
+    },
   });
 
-  const baton = await prisma.item.create({
-    data: {
+  const baton = await prisma.item.upsert({
+    where: { name: 'Bâton magique' },
+    create: {
       name: 'Bâton magique',
       type: ItemType.WEAPON,
       description:
@@ -431,10 +488,19 @@ async function main() {
       shopPrice: 50,
       iconPath: '/assets/items/baton.png',
     },
+    update: {
+      iconPath: '/assets/items/baton.png',
+      shopPrice: 50,
+      statsBonus: { mag: 5 },
+      craftCost: { [cristal.id]: 1, [etoffe.id]: 2 },
+      description:
+        "L'extrémité brille quand on pense très fort à du fromage. Ou à autre chose de plus intime.",
+    },
   });
 
-  const grimoire = await prisma.item.create({
-    data: {
+  const grimoire = await prisma.item.upsert({
+    where: { name: 'Grimoire' },
+    create: {
       name: 'Grimoire',
       type: ItemType.WEAPON,
       description: 'Contient des sorts puissants et des recettes de cuisine douteuses.',
@@ -443,10 +509,18 @@ async function main() {
       shopPrice: 50,
       iconPath: '/assets/items/grimoire.png',
     },
+    update: {
+      iconPath: '/assets/items/grimoire.png',
+      shopPrice: 50,
+      statsBonus: { mag: 3, res: 2 },
+      craftCost: { [cristal.id]: 2, [etoffe.id]: 1 },
+      description: 'Contient des sorts puissants et des recettes de cuisine douteuses.',
+    },
   });
 
-  const kunai = await prisma.item.create({
-    data: {
+  const kunai = await prisma.item.upsert({
+    where: { name: 'Kunaï' },
+    create: {
       name: 'Kunaï',
       type: ItemType.WEAPON,
       description:
@@ -456,10 +530,19 @@ async function main() {
       shopPrice: 50,
       iconPath: '/assets/items/kunai.png',
     },
+    update: {
+      iconPath: '/assets/items/kunai.png',
+      shopPrice: 50,
+      statsBonus: { atk: 3, ini: 2 },
+      craftCost: { [fer.id]: 2, [bois.id]: 1 },
+      description:
+        'Petit, pointu, et facile à cacher. Comme le respect de vos ennemis après une défaite.',
+    },
   });
 
-  const bombe = await prisma.item.create({
-    data: {
+  const bombe = await prisma.item.upsert({
+    where: { name: 'Bombe ninja' },
+    create: {
       name: 'Bombe ninja',
       type: ItemType.WEAPON,
       description:
@@ -469,12 +552,21 @@ async function main() {
       shopPrice: 50,
       iconPath: '/assets/items/bombe.png',
     },
+    update: {
+      iconPath: '/assets/items/bombe.png',
+      shopPrice: 50,
+      statsBonus: { atk: 2, ini: 3 },
+      craftCost: { [bois.id]: 1, [herbe.id]: 2 },
+      description:
+        "Fait 'Pouf' et vous voilà disparu. Ou alors vous avez juste l'air idiot au milieu d'un nuage de fumée.",
+    },
   });
 
-  // ── Armures tête (Cout 2u) ─────────────────────────
+  // ── Armures tête ───────────────────────────────────────────────────
 
-  const heaume = await prisma.item.create({
-    data: {
+  const heaume = await prisma.item.upsert({
+    where: { name: 'Heaume' },
+    create: {
       name: 'Heaume',
       type: ItemType.ARMOR_HEAD,
       description:
@@ -484,10 +576,19 @@ async function main() {
       shopPrice: 50,
       iconPath: '/assets/items/heaume.png',
     },
+    update: {
+      iconPath: '/assets/items/heaume.png',
+      shopPrice: 50,
+      statsBonus: { def: 3 },
+      craftCost: { [fer.id]: 2 },
+      description:
+        "Protège votre tête, mais limite votre champ de vision à celui d'un cyclope bourré.",
+    },
   });
 
-  const chapeau = await prisma.item.create({
-    data: {
+  const chapeau = await prisma.item.upsert({
+    where: { name: 'Chapeau de mage' },
+    create: {
       name: 'Chapeau de mage',
       type: ItemType.ARMOR_HEAD,
       description: 'Plus le chapeau est pointu, plus le mage est... compensatoire.',
@@ -496,10 +597,18 @@ async function main() {
       shopPrice: 50,
       iconPath: '/assets/items/chapeau.png',
     },
+    update: {
+      iconPath: '/assets/items/chapeau.png',
+      shopPrice: 50,
+      statsBonus: { res: 3 },
+      craftCost: { [cristal.id]: 1, [etoffe.id]: 1 },
+      description: 'Plus le chapeau est pointu, plus le mage est... compensatoire.',
+    },
   });
 
-  const bandeau = await prisma.item.create({
-    data: {
+  const bandeau = await prisma.item.upsert({
+    where: { name: 'Bandeau' },
+    create: {
       name: 'Bandeau',
       type: ItemType.ARMOR_HEAD,
       description:
@@ -509,12 +618,21 @@ async function main() {
       shopPrice: 50,
       iconPath: '/assets/items/bandeau.png',
     },
+    update: {
+      iconPath: '/assets/items/bandeau.png',
+      shopPrice: 50,
+      statsBonus: { ini: 3 },
+      craftCost: { [cuir.id]: 1, [bois.id]: 1 },
+      description:
+        'Donne un air de ninja ténébreux, mais sert surtout à éponger la sueur de la peur.',
+    },
   });
 
-  // ── Armures torse (Cout 3u) ────────────────────────
+  // ── Armures torse ──────────────────────────────────────────────────
 
-  const armure = await prisma.item.create({
-    data: {
+  const armure = await prisma.item.upsert({
+    where: { name: 'Armure' },
+    create: {
       name: 'Armure',
       type: ItemType.ARMOR_CHEST,
       description: "Du métal lourd pour gens qui n'ont pas peur de couler au fond de l'eau.",
@@ -523,10 +641,18 @@ async function main() {
       shopPrice: 50,
       iconPath: '/assets/items/armure.png',
     },
+    update: {
+      iconPath: '/assets/items/armure.png',
+      shopPrice: 50,
+      statsBonus: { def: 5 },
+      craftCost: { [fer.id]: 2, [cuir.id]: 1 },
+      description: "Du métal lourd pour gens qui n'ont pas peur de couler au fond de l'eau.",
+    },
   });
 
-  const toge = await prisma.item.create({
-    data: {
+  const toge = await prisma.item.upsert({
+    where: { name: 'Toge de mage' },
+    create: {
       name: 'Toge de mage',
       type: ItemType.ARMOR_CHEST,
       description: 'Très aéré. Un peu trop quand il y a du vent.',
@@ -535,10 +661,18 @@ async function main() {
       shopPrice: 50,
       iconPath: '/assets/items/toge.png',
     },
+    update: {
+      iconPath: '/assets/items/toge.png',
+      shopPrice: 50,
+      statsBonus: { res: 5 },
+      craftCost: { [cristal.id]: 1, [etoffe.id]: 2 },
+      description: 'Très aéré. Un peu trop quand il y a du vent.',
+    },
   });
 
-  const kimono = await prisma.item.create({
-    data: {
+  const kimono = await prisma.item.upsert({
+    where: { name: 'Kimono' },
+    create: {
       name: 'Kimono',
       type: ItemType.ARMOR_CHEST,
       description: 'Élégant et léger. Parfait pour les acrobaties et les fuites désespérées.',
@@ -547,12 +681,20 @@ async function main() {
       shopPrice: 50,
       iconPath: '/assets/items/kimono.png',
     },
+    update: {
+      iconPath: '/assets/items/kimono.png',
+      shopPrice: 50,
+      statsBonus: { ini: 3, pm: 1 },
+      craftCost: { [cuir.id]: 1, [bois.id]: 2 },
+      description: 'Élégant et léger. Parfait pour les acrobaties et les fuites désespérées.',
+    },
   });
 
-  // ── Armures jambes (Cout 2u) ───────────────────────
+  // ── Armures jambes ─────────────────────────────────────────────────
 
-  const bottesFer = await prisma.item.create({
-    data: {
+  const bottesFer = await prisma.item.upsert({
+    where: { name: 'Bottes de fer' },
+    create: {
       name: 'Bottes de fer',
       type: ItemType.ARMOR_LEGS,
       description: 'Pour écraser les orteils avec autorité. Interdit dans les soirées dansantes.',
@@ -561,10 +703,18 @@ async function main() {
       shopPrice: 50,
       iconPath: '/assets/items/bottesFer.png',
     },
+    update: {
+      iconPath: '/assets/items/bottesFer.png',
+      shopPrice: 50,
+      statsBonus: { def: 2, pm: 1 },
+      craftCost: { [fer.id]: 2 },
+      description: 'Pour écraser les orteils avec autorité. Interdit dans les soirées dansantes.',
+    },
   });
 
-  const bottesMage = await prisma.item.create({
-    data: {
+  const bottesMage = await prisma.item.upsert({
+    where: { name: 'Bottes de mage' },
+    create: {
       name: 'Bottes de mage',
       type: ItemType.ARMOR_LEGS,
       description:
@@ -574,10 +724,19 @@ async function main() {
       shopPrice: 50,
       iconPath: '/assets/items/bottesMage.png',
     },
+    update: {
+      iconPath: '/assets/items/bottesMage.png',
+      shopPrice: 50,
+      statsBonus: { res: 2, pm: 1 },
+      craftCost: { [etoffe.id]: 2 },
+      description:
+        "Permettent de marcher sur l'eau, ou au moins de ne pas se mouiller les chaussettes dans l'herbe haute.",
+    },
   });
 
-  const geta = await prisma.item.create({
-    data: {
+  const geta = await prisma.item.upsert({
+    where: { name: 'Geta' },
+    create: {
       name: 'Geta',
       type: ItemType.ARMOR_LEGS,
       description:
@@ -587,12 +746,21 @@ async function main() {
       shopPrice: 50,
       iconPath: '/assets/items/geta.png',
     },
+    update: {
+      iconPath: '/assets/items/geta.png',
+      shopPrice: 50,
+      statsBonus: { pm: 2 },
+      craftCost: { [bois.id]: 2 },
+      description:
+        "Clac-clac-clac. Le bruit de la mort qui arrive... ou d'un touriste en vacances.",
+    },
   });
 
-  // ── Anneaux (Cout 2u famille + 2 Or) ───────────────
+  // ── Anneaux ────────────────────────────────────────────────────────
 
-  const anneauGuerrier = await prisma.item.create({
-    data: {
+  const anneauGuerrier = await prisma.item.upsert({
+    where: { name: 'Anneau du Guerrier' },
+    create: {
       name: 'Anneau du Guerrier',
       type: ItemType.ACCESSORY,
       description:
@@ -602,10 +770,19 @@ async function main() {
       shopPrice: 180,
       iconPath: '/assets/items/anneauGuerrier.png',
     },
+    update: {
+      iconPath: '/assets/items/anneauGuerrier.png',
+      shopPrice: 180,
+      statsBonus: { vit: 85, atk: 20, def: 10, pa: 1 },
+      craftCost: { [fer.id]: 2, [or.id]: 2 },
+      description:
+        'Augmente la force brute. Attention : ne pas se curer le nez avec, sous peine de luxation.',
+    },
   });
 
-  const anneauMage = await prisma.item.create({
-    data: {
+  const anneauMage = await prisma.item.upsert({
+    where: { name: 'Anneau du Mage' },
+    create: {
       name: 'Anneau du Mage',
       type: ItemType.ACCESSORY,
       description: 'Fait circuler le mana. Et provoque des picotements bizarres dans les mains.',
@@ -614,10 +791,18 @@ async function main() {
       shopPrice: 180,
       iconPath: '/assets/items/anneauMage.png',
     },
+    update: {
+      iconPath: '/assets/items/anneauMage.png',
+      shopPrice: 180,
+      statsBonus: { vit: 40, mag: 25, res: 15, pa: 1 },
+      craftCost: { [cristal.id]: 2, [or.id]: 2 },
+      description: 'Fait circuler le mana. Et provoque des picotements bizarres dans les mains.',
+    },
   });
 
-  const anneauNinja = await prisma.item.create({
-    data: {
+  const anneauNinja = await prisma.item.upsert({
+    where: { name: 'Anneau du Ninja' },
+    create: {
       name: 'Anneau du Ninja',
       type: ItemType.ACCESSORY,
       description:
@@ -627,10 +812,19 @@ async function main() {
       shopPrice: 180,
       iconPath: '/assets/items/anneauNinja.png',
     },
+    update: {
+      iconPath: '/assets/items/anneauNinja.png',
+      shopPrice: 180,
+      statsBonus: { vit: 50, atk: 15, mag: 5, ini: 50, pm: 1, pa: 1 },
+      craftCost: { [cuir.id]: 1, [bois.id]: 1, [or.id]: 2 },
+      description:
+        "Rend plus agile. Ou alors c'est juste l'effet placebo de porter un truc brillant.",
+    },
   });
 
-  const anneauPenien = await prisma.item.create({
-    data: {
+  const anneauPenien = await prisma.item.upsert({
+    where: { name: 'Anneau pénien' },
+    create: {
       name: 'Anneau pénien',
       type: ItemType.ACCESSORY,
       description:
@@ -639,8 +833,18 @@ async function main() {
       shopPrice: 500,
       iconPath: '/assets/items/anneauPenien.png',
     },
+    update: {
+      iconPath: '/assets/items/anneauPenien.png',
+      shopPrice: 500,
+      statsBonus: { vit: 9999, atk: 999, mag: 999, def: 100, res: 100, pa: 12, pm: 12 },
+      description:
+        "Un anneau moulé directement sur l'artisan le plus expérimenté de Vergeronce. Il paraît qu'il procure un bonus de 'Vigueur' insoupçonné.",
+    },
   });
 
+  // ItemGrantedSpell: delete+recreate for anneaux (no unique constraint on itemId+spellId)
+  const anneauIds = [anneauGuerrier.id, anneauMage.id, anneauNinja.id, anneauPenien.id];
+  await prisma.itemGrantedSpell.deleteMany({ where: { itemId: { in: anneauIds } } });
   await prisma.itemGrantedSpell.createMany({
     data: [
       { itemId: anneauGuerrier.id, spellId: spellsByCode.get('spell-frappe')!.id },
@@ -664,10 +868,11 @@ async function main() {
     ],
   });
 
-  // ── Consommables : prix bas pour ne pas grignoter le budget équipement ──
+  // ── Consommables ───────────────────────────────────────────────────
 
-  await prisma.item.create({
-    data: {
+  await prisma.item.upsert({
+    where: { name: 'Potion de Soin' },
+    create: {
       name: 'Potion de Soin',
       type: ItemType.CONSUMABLE,
       description:
@@ -677,10 +882,19 @@ async function main() {
       shopPrice: 15,
       iconPath: '/assets/items/potionSoin.png',
     },
+    update: {
+      iconPath: '/assets/items/potionSoin.png',
+      shopPrice: 15,
+      statsBonus: { healVit: 30 },
+      craftCost: { [herbe.id]: 2 },
+      description:
+        'Boire cul-sec pour refermer ses plaies. Goût fraise des bois et vieux pansement.',
+    },
   });
 
-  await prisma.item.create({
-    data: {
+  await prisma.item.upsert({
+    where: { name: 'Potion de Force' },
+    create: {
       name: 'Potion de Force',
       type: ItemType.CONSUMABLE,
       description:
@@ -690,10 +904,19 @@ async function main() {
       shopPrice: 15,
       iconPath: '/assets/items/potionForce.png',
     },
+    update: {
+      iconPath: '/assets/items/potionForce.png',
+      shopPrice: 15,
+      statsBonus: { buffAttaque: 5, buffDuree: 3 },
+      craftCost: { [fer.id]: 1, [herbe.id]: 1 },
+      description:
+        'Vous donne des muscles en carton pendant 3 minutes. Attention au contrecoup sur votre dignité.',
+    },
   });
 
-  await prisma.item.create({
-    data: {
+  await prisma.item.upsert({
+    where: { name: 'Potion de Vitesse' },
+    create: {
       name: 'Potion de Vitesse',
       type: ItemType.CONSUMABLE,
       description: 'Pour courir plus vite que son ombre. Ou que sa propre honte.',
@@ -702,150 +925,151 @@ async function main() {
       shopPrice: 15,
       iconPath: '/assets/items/potionVitesse.png',
     },
+    update: {
+      iconPath: '/assets/items/potionVitesse.png',
+      shopPrice: 15,
+      statsBonus: { buffPM: 2, buffDuree: 2 },
+      craftCost: { [bois.id]: 1, [herbe.id]: 1 },
+      description: 'Pour courir plus vite que son ombre. Ou que sa propre honte.',
+    },
   });
 
-  // ── Joueurs de test ──────────────────────────────────────────────
+  // ── Joueurs de test : find-or-create (préserve les vraies données) ──
 
   const passwordHash = await bcrypt.hash('password123', 10);
 
-  const warrior = await prisma.player.create({
-    data: {
-      username: 'Warrior',
-      email: 'warrior@test.com',
-      passwordHash,
-      gold: 100,
-      stats: {
-        create: createDefaultPlayerStats(),
+  const warriorExists = await prisma.player.findUnique({ where: { email: 'warrior@test.com' } });
+  if (!warriorExists) {
+    const warrior = await prisma.player.create({
+      data: {
+        username: 'Warrior',
+        email: 'warrior@test.com',
+        passwordHash,
+        gold: 100,
+        stats: { create: createDefaultPlayerStats() },
+        inventory: {
+          create: [
+            { itemId: epee.id, quantity: 1 },
+            { itemId: bouclier.id, quantity: 1 },
+            { itemId: heaume.id, quantity: 1 },
+            { itemId: armure.id, quantity: 1 },
+            { itemId: bottesFer.id, quantity: 1 },
+            { itemId: anneauGuerrier.id, quantity: 1 },
+            { itemId: anneauPenien.id, quantity: 1 },
+          ],
+        },
       },
-
-      inventory: {
-        create: [
-          { itemId: epee.id, quantity: 1 },
-          { itemId: bouclier.id, quantity: 1 },
-          { itemId: heaume.id, quantity: 1 },
-          { itemId: armure.id, quantity: 1 },
-          { itemId: bottesFer.id, quantity: 1 },
-          { itemId: anneauGuerrier.id, quantity: 1 },
-          { itemId: anneauPenien.id, quantity: 1 },
-        ],
+    });
+    const warriorInv = await prisma.inventoryItem.findMany({ where: { playerId: warrior.id } });
+    await prisma.equipmentSlot.create({
+      data: {
+        playerId: warrior.id,
+        slot: EquipmentSlotType.ACCESSORY,
+        inventoryItemId: warriorInv.find((i) => i.itemId === anneauGuerrier.id)?.id,
       },
-    },
-  });
+    });
+    await rebuildPlayerSpellsForPlayer(warrior.id);
+  }
 
-  // Seul l'anneau est équipé
-  const warriorInv = await prisma.inventoryItem.findMany({ where: { playerId: warrior.id } });
-  await prisma.equipmentSlot.create({
-    data: {
-      playerId: warrior.id,
-      slot: EquipmentSlotType.ACCESSORY,
-      inventoryItemId: warriorInv.find((i) => i.itemId === anneauGuerrier.id)?.id,
-    },
-  });
-
-  const mage = await prisma.player.create({
-    data: {
-      username: 'Mage',
-      email: 'mage@test.com',
-      passwordHash,
-      gold: 100,
-      stats: {
-        create: createDefaultPlayerStats(),
+  const mageExists = await prisma.player.findUnique({ where: { email: 'mage@test.com' } });
+  if (!mageExists) {
+    const mage = await prisma.player.create({
+      data: {
+        username: 'Mage',
+        email: 'mage@test.com',
+        passwordHash,
+        gold: 100,
+        stats: { create: createDefaultPlayerStats() },
+        inventory: {
+          create: [
+            { itemId: baton.id, quantity: 1 },
+            { itemId: grimoire.id, quantity: 1 },
+            { itemId: chapeau.id, quantity: 1 },
+            { itemId: toge.id, quantity: 1 },
+            { itemId: bottesMage.id, quantity: 1 },
+            { itemId: anneauMage.id, quantity: 1 },
+          ],
+        },
       },
-
-      inventory: {
-        create: [
-          { itemId: baton.id, quantity: 1 },
-          { itemId: grimoire.id, quantity: 1 },
-          { itemId: chapeau.id, quantity: 1 },
-          { itemId: toge.id, quantity: 1 },
-          { itemId: bottesMage.id, quantity: 1 },
-          { itemId: anneauMage.id, quantity: 1 },
-        ],
+    });
+    const mageInv = await prisma.inventoryItem.findMany({ where: { playerId: mage.id } });
+    await prisma.equipmentSlot.create({
+      data: {
+        playerId: mage.id,
+        slot: EquipmentSlotType.ACCESSORY,
+        inventoryItemId: mageInv.find((i) => i.itemId === anneauMage.id)?.id,
       },
-    },
-  });
+    });
+    await rebuildPlayerSpellsForPlayer(mage.id);
+  }
 
-  const mageInv = await prisma.inventoryItem.findMany({ where: { playerId: mage.id } });
-  await prisma.equipmentSlot.create({
-    data: {
-      playerId: mage.id,
-      slot: EquipmentSlotType.ACCESSORY,
-      inventoryItemId: mageInv.find((i) => i.itemId === anneauMage.id)?.id,
-    },
-  });
-
-  const ninja = await prisma.player.create({
-    data: {
-      username: 'Ninja',
-      email: 'ninja@test.com',
-      passwordHash,
-      gold: 100,
-      stats: {
-        create: createDefaultPlayerStats(),
+  const ninjaExists = await prisma.player.findUnique({ where: { email: 'ninja@test.com' } });
+  if (!ninjaExists) {
+    const ninja = await prisma.player.create({
+      data: {
+        username: 'Ninja',
+        email: 'ninja@test.com',
+        passwordHash,
+        gold: 100,
+        stats: { create: createDefaultPlayerStats() },
+        inventory: {
+          create: [
+            { itemId: kunai.id, quantity: 1 },
+            { itemId: bombe.id, quantity: 1 },
+            { itemId: bandeau.id, quantity: 1 },
+            { itemId: kimono.id, quantity: 1 },
+            { itemId: geta.id, quantity: 1 },
+            { itemId: anneauNinja.id, quantity: 1 },
+          ],
+        },
       },
-      inventory: {
-        create: [
-          { itemId: kunai.id, quantity: 1 },
-          { itemId: bombe.id, quantity: 1 },
-          { itemId: bandeau.id, quantity: 1 },
-          { itemId: kimono.id, quantity: 1 },
-          { itemId: geta.id, quantity: 1 },
-          { itemId: anneauNinja.id, quantity: 1 },
-        ],
+    });
+    const ninjaInv = await prisma.inventoryItem.findMany({ where: { playerId: ninja.id } });
+    await prisma.equipmentSlot.create({
+      data: {
+        playerId: ninja.id,
+        slot: EquipmentSlotType.ACCESSORY,
+        inventoryItemId: ninjaInv.find((i) => i.itemId === anneauNinja.id)?.id,
       },
-    },
-  });
+    });
+    await rebuildPlayerSpellsForPlayer(ninja.id);
+  }
 
-  const ninjaInv = await prisma.inventoryItem.findMany({ where: { playerId: ninja.id } });
-  await prisma.equipmentSlot.create({
-    data: {
-      playerId: ninja.id,
-      slot: EquipmentSlotType.ACCESSORY,
-      inventoryItemId: ninjaInv.find((i) => i.itemId === anneauNinja.id)?.id,
-    },
-  });
-
-  const troll = await prisma.player.create({
-    data: {
-      username: 'Troll pénien',
-      email: 'troll@test.com',
-      passwordHash,
-      gold: 100,
-      skin: 'orc-blood',
-      stats: {
-        create: createDefaultPlayerStats(),
+  const trollExists = await prisma.player.findUnique({ where: { email: 'troll@test.com' } });
+  if (!trollExists) {
+    const troll = await prisma.player.create({
+      data: {
+        username: 'Troll pénien',
+        email: 'troll@test.com',
+        passwordHash,
+        gold: 100,
+        skin: 'orc-blood',
+        stats: { create: createDefaultPlayerStats() },
+        inventory: {
+          create: [
+            { itemId: anneauPenien.id, quantity: 1 },
+            { itemId: or.id, quantity: 69 },
+          ],
+        },
       },
-      inventory: {
-        create: [
-          { itemId: anneauPenien.id, quantity: 1 },
-          { itemId: or.id, quantity: 69 },
-        ],
+    });
+    const trollInv = await prisma.inventoryItem.findMany({ where: { playerId: troll.id } });
+    await prisma.equipmentSlot.create({
+      data: {
+        playerId: troll.id,
+        slot: EquipmentSlotType.ACCESSORY,
+        inventoryItemId: trollInv.find((i) => i.itemId === anneauPenien.id)?.id,
       },
-    },
-  });
-
-  const trollInv = await prisma.inventoryItem.findMany({ where: { playerId: troll.id } });
-  await prisma.equipmentSlot.create({
-    data: {
-      playerId: troll.id,
-      slot: EquipmentSlotType.ACCESSORY,
-      inventoryItemId: trollInv.find((i) => i.itemId === anneauPenien.id)?.id,
-    },
-  });
-
-  await Promise.all([
-    rebuildPlayerSpellsForPlayer(warrior.id),
-    rebuildPlayerSpellsForPlayer(mage.id),
-    rebuildPlayerSpellsForPlayer(ninja.id),
-    rebuildPlayerSpellsForPlayer(troll.id),
-  ]);
+    });
+    await rebuildPlayerSpellsForPlayer(troll.id);
+  }
 
   const itemCount = await prisma.item.count();
   const spellCount = await prisma.spell.count();
   console.log('✅ Seed completed!');
   console.log(`   Items: ${itemCount}`);
   console.log(`   Spells: ${spellCount}`);
-  console.log(`   Players: Warrior, Mage, Ninja, Troll pénien`);
+  console.log(`   Players: Warrior, Mage, Ninja, Troll pénien (skipped if already exist)`);
 }
 
 main()


### PR DESCRIPTION
…n redeploy

Replace create() with upsert() for all items and spells so that re-running the seed (e.g. after a deploy) updates iconPath, shopPrice, descriptions without wiping the database. Session/combat data is still cleared. Test players use find-or-create so existing accounts and progress are preserved.