### PR TITLE
chore(nx): add scope:frontend type:app tags to web project

### DIFF
--- a/apps/web/project.json
+++ b/apps/web/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "apps/web/src",
   "projectType": "application",
-  "tags": [],
+  "tags": ["scope:frontend", "type:app"],
   "// targets": "to see all targets run: nx show project web --web",
   "targets": {
     "test": {


### PR DESCRIPTION
## Summary
- Ajoute `scope:frontend` et `type:app` dans `apps/web/project.json`
- Corrige un angle mort : sans tags, les règles `@nx/enforce-module-boundaries` ne s'appliquaient pas au projet `web`

## Test plan
- [ ] `yarn lint` passe sans erreur de boundary
- [ ] `nx graph` affiche correctement les dépendances de `web`

🤖 Generated with [Claude Code](https://claude.com/claude-code)