### PR TITLE
chore(coverage): add test coverage baseline and regression check

### DIFF
--- a/.github/workflows/_quality-gates.yml
+++ b/.github/workflows/_quality-gates.yml
@@ -91,6 +91,12 @@ jobs:
       - name: Enforce coverage thresholds
         run: bash scripts/ci/check-coverage-thresholds.sh
 
+      - name: Test with coverage
+        run: yarn test:coverage
+
+      - name: Coverage regression check
+        run: node scripts/ci/coverage-compare.mjs
+
   prod-like-smoke:
     name: Prod-like Docker Smoke
     runs-on: ubuntu-latest

--- a/apps/api/jest.config.cts
+++ b/apps/api/jest.config.cts
@@ -10,13 +10,13 @@ module.exports = {
   // sont lancés via `yarn nx test:integration api`.
   testMatch: ['<rootDir>/src/**/*.spec.ts', '<rootDir>/src/**/*.test.ts'],
   coverageDirectory: '../../coverage/apps/api',
-  coverageReporters: ['text', 'html', 'lcov', 'json-summary'],
-  coveragePathIgnorePatterns: [
-    '/node_modules/',
-    '<rootDir>/src/test/',
-    '<rootDir>/src/main.ts',
-    '\\.module\\.ts$',
-    '\\.dto\\.ts$',
-    '\\.d\\.ts$',
+  coverageProvider: 'v8',
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.spec.ts',
+    '!src/**/*.module.ts',
+    '!src/main.ts',
+    '!src/**/*.d.ts',
   ],
+  coverageReporters: ['text', 'html', 'lcov', 'json-summary'],
 };

--- a/coverage/baseline.json
+++ b/coverage/baseline.json
@@ -1,0 +1,16 @@
+{
+  "api": {
+    "lines": { "pct": 0 },
+    "statements": { "pct": 0 },
+    "functions": { "pct": 0 },
+    "branches": { "pct": 0 }
+  },
+  "web": {
+    "lines": { "pct": 12.73 },
+    "statements": { "pct": 13 },
+    "functions": { "pct": 14.12 },
+    "branches": { "pct": 8.23 }
+  },
+  "updatedAt": "2026-04-25",
+  "_note": "API baseline at 0 until first CI run with DB. Run 'yarn test:coverage:update' to refresh."
+}

--- a/coverage/baseline.json
+++ b/coverage/baseline.json
@@ -1,15 +1,15 @@
 {
   "api": {
-    "lines": { "pct": 0 },
-    "statements": { "pct": 0 },
-    "functions": { "pct": 0 },
-    "branches": { "pct": 0 }
+    "lines": 0,
+    "statements": 0,
+    "functions": 0,
+    "branches": 0
   },
   "web": {
-    "lines": { "pct": 12.73 },
-    "statements": { "pct": 13 },
-    "functions": { "pct": 14.12 },
-    "branches": { "pct": 8.23 }
+    "lines": 12.73,
+    "statements": 13,
+    "functions": 14.12,
+    "branches": 8.23
   },
   "updatedAt": "2026-04-25",
   "_note": "API baseline at 0 until first CI run with DB. Run 'yarn test:coverage:update' to refresh."

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "perf:api:compare": "PERF_API_PORT=3100 PERF_PROD_PORT=3101 dotenv -e .env -- node scripts/perf/compare.mjs",
     "build": "dotenv -e .env -- nx run-many --target=build --all",
     "test": "dotenv -e .env -- nx run-many --target=test --all",
+    "test:coverage": "dotenv -e .env -- nx run-many --target=test --all -- --coverage",
+    "test:coverage:update": "yarn test:coverage && node scripts/ci/coverage-compare.mjs --update",
     "lint": "dotenv -e .env -- nx run-many --target=lint --all",
     "db:migrate": "prisma migrate dev --schema=apps/api/prisma/schema.prisma",
     "db:migrate:deploy": "dotenv -e .env -- prisma migrate deploy --schema=apps/api/prisma/schema.prisma",

--- a/scripts/ci/coverage-compare.mjs
+++ b/scripts/ci/coverage-compare.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+/**
+ * Compares current test coverage against the committed baseline.
+ * Exits with code 1 if any metric regresses.
+ *
+ * Usage:
+ *   node scripts/ci/coverage-compare.mjs              # compare mode (CI)
+ *   node scripts/ci/coverage-compare.mjs --update     # update baseline file
+ */
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '../..');
+
+const BASELINE_PATH = resolve(root, 'coverage/baseline.json');
+const API_SUMMARY = resolve(root, 'coverage/apps/api/coverage-summary.json');
+const WEB_SUMMARY = resolve(root, 'coverage/apps/web/coverage-summary.json');
+
+const METRICS = ['lines', 'statements', 'functions', 'branches'];
+
+function readSummary(path, project) {
+  if (!existsSync(path)) {
+    console.error(`❌  Coverage summary not found for ${project}: ${path}`);
+    console.error(`    Run: yarn test:coverage`);
+    process.exit(1);
+  }
+  const raw = JSON.parse(readFileSync(path, 'utf8'));
+  const total = raw.total ?? raw;
+  return Object.fromEntries(METRICS.map((m) => [m, total[m]?.pct ?? 0]));
+}
+
+function formatPct(n) {
+  return `${n.toFixed(2)}%`;
+}
+
+const isUpdate = process.argv.includes('--update');
+
+const api = readSummary(API_SUMMARY, 'api');
+const web = readSummary(WEB_SUMMARY, 'web');
+
+if (isUpdate) {
+  const baseline = {
+    api,
+    web,
+    updatedAt: new Date().toISOString().slice(0, 10),
+  };
+  writeFileSync(BASELINE_PATH, JSON.stringify(baseline, null, 2) + '\n');
+  console.log('✅  Coverage baseline updated:', BASELINE_PATH);
+  for (const [project, metrics] of Object.entries({ api, web })) {
+    console.log(`\n  ${project}:`);
+    for (const m of METRICS) {
+      console.log(`    ${m.padEnd(12)} ${formatPct(metrics[m])}`);
+    }
+  }
+  process.exit(0);
+}
+
+if (!existsSync(BASELINE_PATH)) {
+  console.warn('⚠️   No baseline found. Run with --update to create one.');
+  process.exit(0);
+}
+
+const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
+let failed = false;
+
+for (const [project, current] of Object.entries({ api, web })) {
+  const base = baseline[project] ?? {};
+  console.log(`\n  ${project} (baseline: ${baseline.updatedAt ?? 'unknown'}):`);
+  for (const m of METRICS) {
+    const cur = current[m] ?? 0;
+    const ref = base[m] ?? 0;
+    const diff = cur - ref;
+    const sign = diff >= 0 ? '+' : '';
+    const ok = diff >= 0;
+    const icon = ok ? '✅' : '❌';
+    console.log(
+      `  ${icon}  ${m.padEnd(12)} ${formatPct(cur).padStart(8)}  (baseline ${formatPct(ref)}, ${sign}${formatPct(diff)})`,
+    );
+    if (!ok) failed = true;
+  }
+}
+
+if (failed) {
+  console.error('\n❌  Coverage regression detected. Fix tests or update baseline.\n');
+  process.exit(1);
+} else {
+  console.log('\n✅  No coverage regression.\n');
+}


### PR DESCRIPTION
## Summary
- Active la mesure de couverture (v8) dans Jest (api) et Vitest (web)
- Ajoute `@vitest/coverage-v8` en devDependency
- Nouveau script `scripts/ci/coverage-compare.mjs` : compare le run actuel au `coverage/baseline.json` committé, sort 1 en cas de régression
- Nouveaux scripts `yarn test:coverage` et `yarn test:coverage:update`
- `_quality-gates.yml` : run coverage + check à chaque CI
- Baseline initiale : web 13% stmt / 8.2% branches ; API à 0 (mettre à jour avec `yarn test:coverage:update` une fois la DB dispo en CI)

## Test plan
- [ ] `yarn test:coverage` génère `coverage/apps/*/coverage-summary.json`
- [ ] `node scripts/ci/coverage-compare.mjs` passe sans erreur sur la baseline actuelle
- [ ] `node scripts/ci/coverage-compare.mjs --update` met à jour `coverage/baseline.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)