### PR TITLE
chore(eslint): promote warn rules to error

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -60,7 +60,7 @@ export default [
     },
     rules: {
       '@typescript-eslint/no-explicit-any': 'error',
-      '@typescript-eslint/explicit-function-return-type': 'warn',
+      '@typescript-eslint/explicit-function-return-type': 'error',
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
       '@typescript-eslint/consistent-type-imports': 'error',
       'import/no-cycle': 'error',
@@ -72,7 +72,7 @@ export default [
           alphabetize: { order: 'asc' },
         },
       ],
-      'no-console': ['warn', { allow: ['warn', 'error'] }],
+      'no-console': ['error', { allow: ['warn', 'error'] }],
       'unicorn/no-array-for-each': 'error',
       'unicorn/prefer-node-protocol': 'error',
     },


### PR DESCRIPTION
## Summary
- `@typescript-eslint/explicit-function-return-type` : `warn` → `error`
- `no-console` : `warn` → `error` (console.warn/error toujours autorisés)

## ⚠️ Ordre de merge
Ce PR doit être mergé **après** `chore/eslint-debt-cleanup` — les violations sont corrigées là-bas, ce PR rend seulement la règle bloquante.

## Test plan
- [ ] Après merge de `chore/eslint-debt-cleanup`, `yarn lint` passe sans erreur

🤖 Generated with [Claude Code](https://claude.com/claude-code)