### PR TITLE
feat(dev): commande dev:host pour démo réseau local

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev:api": "dotenv -e .env -- nx serve api",
     "dev:web": "dotenv -e .env -- nx serve web",
     "dev": "dotenv -e .env -- nx run-many --target=serve --projects=api,web --parallel",
+    "dev:host": "dotenv -e .env -- node scripts/dev/host.mjs",
     "perf:api:start": "PERF_API_PORT=3100 PERF_PROD_PORT=3101 dotenv -e .env -- node scripts/perf/start.mjs",
     "perf:api:baseline": "PERF_API_PORT=3100 PERF_PROD_PORT=3101 dotenv -e .env -- node scripts/perf/baseline.mjs",
     "perf:api:prod-start": "PERF_API_PORT=3100 PERF_PROD_PORT=3101 dotenv -e .env -- node scripts/perf/prod-start.mjs",

--- a/scripts/dev/host.mjs
+++ b/scripts/dev/host.mjs
@@ -1,0 +1,57 @@
+import { spawn } from 'node:child_process';
+import { networkInterfaces } from 'node:os';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '..', '..');
+
+function getLanAddress() {
+  const interfaces = networkInterfaces();
+  for (const addresses of Object.values(interfaces)) {
+    for (const address of addresses ?? []) {
+      if (address.family === 'IPv4' && !address.internal) {
+        return address.address;
+      }
+    }
+  }
+  return null;
+}
+
+const webPort = process.env.VITE_PORT ?? '5173';
+const lanAddress = getLanAddress();
+
+const env = {
+  ...process.env,
+  VITE_HOST: '0.0.0.0',
+};
+
+if (lanAddress) {
+  const lanUrl = `http://${lanAddress}:${webPort}`;
+  console.warn('');
+  console.warn('  Mode demo — accessible depuis le reseau local (telephone, autre PC) :');
+  console.warn(`    Local   : http://localhost:${webPort}`);
+  console.warn(`    Reseau  : ${lanUrl}`);
+  console.warn('  Les deux appareils doivent etre sur le meme reseau Wi-Fi/LAN.');
+  console.warn('');
+} else {
+  console.warn('');
+  console.warn('  Impossible de detecter une adresse IP de reseau local.');
+  console.warn(`  Le serveur ecoute sur 0.0.0.0:${webPort} (toutes interfaces).`);
+  console.warn('');
+}
+
+const child = spawn(
+  'nx',
+  ['run-many', '--target=serve', '--projects=api,web', '--parallel'],
+  {
+    cwd: repoRoot,
+    env,
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  },
+);
+
+child.on('exit', (code) => {
+  process.exit(code ?? 0);
+});


### PR DESCRIPTION
## Pourquoi

Permettre de connecter un autre appareil (téléphone, autre PC) à l'app en cours de dev — utile pour les démos.

## Ce que ça fait

Nouvelle commande : `yarn dev:host`

- `scripts/dev/host.mjs` détecte l'IP LAN de la machine, affiche l'URL réseau à ouvrir sur l'autre appareil, puis lance l'API + le web avec Vite bindé sur `0.0.0.0`.
- Le `vite.config.ts` supportait déjà `VITE_HOST` ; le script le force à `0.0.0.0`.

## Pourquoi c'est suffisant

Le front appelle `/api/v1` **via le proxy Vite** (côté serveur → `localhost:3000`), donc seul le serveur Vite a besoin d'être exposé :
- pas besoin d'exposer l'API directement,
- pas de souci CORS (le navigateur de l'appareil voit la même origine que Vite),
- HMR fonctionne via l'hôte LAN par défaut.

## Usage

\`\`\`bash
yarn dev:host
# ouvre l'URL "Reseau" affichée sur le téléphone/PC (même Wi-Fi/LAN)
\`\`\`

Aucune modif de la config CORS de l'API ni du `.env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)