### PR TITLE
fix(farm/combat/hub): récolte bloquante, zoom combat, caméra hub, redirection combat aléatoire, matchmaking, flash de chargement

### DIFF
--- a/apps/api/src/combat/session/session.service.spec.ts
+++ b/apps/api/src/combat/session/session.service.spec.ts
@@ -39,6 +39,26 @@ describe('SessionService', () => {
             player: {
               findUnique: jest.fn(),
             },
+            gameSession: {
+              findFirst: jest.fn(),
+            },
+            item: {
+              findUnique: jest.fn(),
+            },
+            inventoryItem: {
+              findFirst: jest.fn(),
+              create: jest.fn(),
+            },
+            equipmentSlot: {
+              upsert: jest.fn(),
+            },
+            playerStats: {
+              update: jest.fn(),
+            },
+            playerSpell: {
+              deleteMany: jest.fn(),
+              createMany: jest.fn(),
+            },
           },
         },
         {
@@ -60,6 +80,7 @@ describe('SessionService', () => {
           useValue: {
             syncPlayerSpells: jest.fn(),
             getCombatSpellDefinitions: jest.fn(),
+            buildPlayerSpellAssignments: jest.fn().mockResolvedValue([]),
           },
         },
         {
@@ -70,7 +91,9 @@ describe('SessionService', () => {
         },
         {
           provide: StatsCalculatorService,
-          useValue: {},
+          useValue: {
+            computeEffectiveStats: jest.fn().mockResolvedValue({}),
+          },
         },
         {
           provide: MapService,
@@ -200,6 +223,34 @@ describe('SessionService', () => {
       expect(state.players[player1Id].type).toBe('PLAYER');
       expect(state.players[player2Id].type).toBe('PLAYER');
       expect(redisService.setJson).toHaveBeenCalledWith(`combat:${sessionId}`, state, 3600);
+    });
+  });
+
+  describe('startQuickVsAiCombat', () => {
+    it('links the combat to the active game session so the phase is reconciled at end', async () => {
+      jest.spyOn(service as unknown as { getOrCreateBot: () => Promise<{ id: string }> }, 'getOrCreateBot')
+        .mockResolvedValue({ id: 'bot-1' });
+      const acceptSpy = jest.spyOn(service, 'accept').mockResolvedValue({} as never);
+
+      (prismaService.item.findUnique as jest.Mock).mockResolvedValue({ id: 'ring-1', type: 'ACCESSORY' });
+      (prismaService.inventoryItem.findFirst as jest.Mock).mockResolvedValue({ id: 'inv-1' });
+      (prismaService.equipmentSlot.upsert as jest.Mock).mockResolvedValue({});
+      (prismaService.playerStats.update as jest.Mock).mockResolvedValue({});
+      (prismaService.playerSpell.deleteMany as jest.Mock).mockResolvedValue({});
+      (prismaService.gameSession.findFirst as jest.Mock).mockResolvedValue({ id: 'game-session-1' });
+      (prismaService.combatSession.create as jest.Mock).mockResolvedValue({ id: 'combat-1' });
+
+      await service.startQuickVsAiCombat('player-1', 'ring-1');
+
+      expect(prismaService.combatSession.create).toHaveBeenCalledWith({
+        data: {
+          player1Id: 'player-1',
+          player2Id: 'bot-1',
+          status: 'WAITING',
+          gameSessionId: 'game-session-1',
+        },
+      });
+      expect(acceptSpy).toHaveBeenCalledWith('combat-1', 'bot-1');
     });
   });
 });

--- a/apps/api/src/combat/session/session.service.ts
+++ b/apps/api/src/combat/session/session.service.ts
@@ -452,11 +452,22 @@ export class SessionService {
       await this.prisma.playerSpell.createMany({ data: spellAssignments });
     }
 
+    // Lier le combat à la session active (comme startVsAiCombat / startTestCombat) :
+    // sans gameSessionId, endCombat ne réconcilie jamais la phase et le joueur n'est
+    // pas redirigé du mode farming vers le mode ressource après un combat aléatoire.
+    const activeSession = await this.prisma.gameSession.findFirst({
+      where: {
+        OR: [{ player1Id: challengerId }, { player2Id: challengerId }],
+        status: 'ACTIVE',
+      },
+    });
+
     const session = await this.prisma.combatSession.create({
       data: {
         player1Id: challengerId,
         player2Id: bot.id,
         status: 'WAITING',
+        gameSessionId: activeSession?.id,
       },
     });
 

--- a/apps/web/src/game/Hub3D/HubCamera.tsx
+++ b/apps/web/src/game/Hub3D/HubCamera.tsx
@@ -18,7 +18,7 @@ import {
   CAMERA_ORBIT_RADIUS,
   CAMERA_ZOOM_SENSITIVITY,
 } from './constants';
-import { pickCameraViewportConfig, useViewportMode } from './viewport';
+import { pickCameraViewportConfig, useViewportMode, type CameraViewportConfig } from './viewport';
 
 interface HubCameraProps {
   wasDraggingRef: MutableRefObject<boolean>;
@@ -61,7 +61,7 @@ interface OrbitListenersConfig {
 }
 
 interface DragState {
-  rightDragging: boolean;
+  leftDragging: boolean;
   prevX: number;
   prevY: number;
   leftDragDistance: number;
@@ -70,25 +70,21 @@ interface DragState {
 function nowS(): number { return performance.now() / 1000; }
 
 function handleOrbitPointerDown(event: PointerEvent, state: DragState, cfg: OrbitListenersConfig): void {
-  if (event.button === 2) {
-    state.rightDragging = true;
-    state.prevX = event.clientX;
-    state.prevY = event.clientY;
-    cfg.lastInteractionRef.current = nowS();
-    return;
-  }
-  if (event.button === 0) {
-    state.leftDragDistance = 0;
-    cfg.wasDraggingRef.current = false;
-    state.prevX = event.clientX;
-    state.prevY = event.clientY;
-  }
+  // Bouton gauche : prépare un éventuel drag caméra. Sous le seuil c'est un clic-au-sol
+  // (déplacement du pion) ; au-delà, on oriente la caméra.
+  if (event.button !== 0) return;
+  state.leftDragging = true;
+  state.leftDragDistance = 0;
+  cfg.wasDraggingRef.current = false;
+  state.prevX = event.clientX;
+  state.prevY = event.clientY;
 }
 
 function applyOrbitDelta(dx: number, dy: number, cfg: OrbitListenersConfig): void {
   cfg.azimuthRef.current -= dx * cfg.rotateSensitivity;
+  // +dy : tirer vers le haut élève la vue (axe vertical non inversé).
   cfg.elevationRef.current = clamp(
-    cfg.elevationRef.current - dy * cfg.rotateSensitivity,
+    cfg.elevationRef.current + dy * cfg.rotateSensitivity,
     CAMERA_ORBIT_MIN_ELEVATION,
     CAMERA_ORBIT_MAX_ELEVATION,
   );
@@ -96,17 +92,15 @@ function applyOrbitDelta(dx: number, dy: number, cfg: OrbitListenersConfig): voi
 }
 
 function handleOrbitPointerMove(event: PointerEvent, state: DragState, cfg: OrbitListenersConfig): void {
+  if (!state.leftDragging || !(event.buttons & 1)) return;
   const dx = event.clientX - state.prevX;
   const dy = event.clientY - state.prevY;
   state.prevX = event.clientX;
   state.prevY = event.clientY;
-  if (state.rightDragging) {
+  state.leftDragDistance += Math.hypot(dx, dy);
+  if (state.leftDragDistance > cfg.dragThresholdPx) {
+    cfg.wasDraggingRef.current = true;
     applyOrbitDelta(dx, dy, cfg);
-    return;
-  }
-  if (event.buttons & 1) {
-    state.leftDragDistance += Math.hypot(dx, dy);
-    if (state.leftDragDistance > cfg.dragThresholdPx) cfg.wasDraggingRef.current = true;
   }
 }
 
@@ -152,11 +146,11 @@ function stepCamera({ camera, pivot, refs, delta, t }: StepCameraArgs): void {
 }
 
 function attachOrbitListeners(cfg: OrbitListenersConfig): () => void {
-  const state: DragState = { rightDragging: false, prevX: 0, prevY: 0, leftDragDistance: 0 };
+  const state: DragState = { leftDragging: false, prevX: 0, prevY: 0, leftDragDistance: 0 };
 
   const onDown = (e: PointerEvent): void => handleOrbitPointerDown(e, state, cfg);
   const onMove = (e: PointerEvent): void => handleOrbitPointerMove(e, state, cfg);
-  const onUp = (e: PointerEvent): void => { if (e.button === 2) state.rightDragging = false; };
+  const onUp = (e: PointerEvent): void => { if (e.button === 0) state.leftDragging = false; };
   const onWheel = (e: WheelEvent): void => {
     cfg.zoomRef.current = clamp(
       cfg.zoomRef.current - e.deltaY * CAMERA_ZOOM_SENSITIVITY,
@@ -240,8 +234,8 @@ export function HubCamera({ wasDraggingRef, enabled }: HubCameraProps): ReactEle
         Math.cos(CAMERA_ORBIT_INITIAL_AZIMUTH) * Math.cos(CAMERA_ORBIT_INITIAL_ELEVATION) * CAMERA_ORBIT_RADIUS,
       ]}
       zoom={viewportConfig.zoom}
-      near={0.1}
-      far={300}
+      near={-500}
+      far={1000}
     />
   );
 }

--- a/apps/web/src/pages/CombatPage.tsx
+++ b/apps/web/src/pages/CombatPage.tsx
@@ -179,10 +179,12 @@ export function CombatPage() {
               near={0.1}
               far={1000}
             />
-            <CameraControls 
-              ref={controlsRef} 
-              onRest={onRest} 
+            <CameraControls
+              ref={controlsRef}
+              onRest={onRest}
               onStart={onStart}
+              minZoom={15}
+              maxZoom={80}
               minPolarAngle={0}
               maxPolarAngle={Math.PI / 2.1}
               mouseButtons={{

--- a/apps/web/src/pages/FarmingPage.tsx
+++ b/apps/web/src/pages/FarmingPage.tsx
@@ -95,6 +95,7 @@ export function FarmingPage() {
   const [movePath, setMovePath] = useState<PathNode[] | null>(null);
   const [isMoving, setIsMoving] = useState(false);
   const [isMapSceneReady, setIsMapSceneReady] = useState(false);
+  const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
   const [, setIsTransitioning] = useState(false);
   const [statsOpen, setStatsOpen] = useState(true);
   const isActionInProgressRef = useRef(false);
@@ -137,6 +138,13 @@ export function FarmingPage() {
 
   const { active: isAssetLoading, progress: assetLoadProgress } = useProgress();
   const isFarmingLoaded = Boolean(map && isMapSceneReady && !isAssetLoading);
+  // N'afficher l'écran de chargement qu'au tout premier chargement. Sinon il réapparaît à
+  // chaque récolte (le swap de modèle 3D de la case relance useProgress().active) ; et comme
+  // c'est un overlay plein écran qui capture les clics (z-index 9999, sans pointer-events:none),
+  // il « bloque » le perso en avalant les clics de déplacement suivants.
+  useEffect(() => {
+    if (isFarmingLoaded) setHasLoadedOnce(true);
+  }, [isFarmingLoaded]);
 
   // -- Data Fetching --
   const { data: inventoryData } = useQuery({
@@ -472,7 +480,7 @@ export function FarmingPage() {
 
   return (
     <div className="farming-page-layout">
-      {!isFarmingLoaded && (
+      {!hasLoadedOnce && (
         <div className="loading-screen farming-loading-screen" role="status" aria-live="polite">
           <span>⚔️ {t('loading')}</span>
           {isAssetLoading && <small>{loadingProgress}%</small>}

--- a/apps/web/src/pages/FarmingPage.tsx
+++ b/apps/web/src/pages/FarmingPage.tsx
@@ -402,10 +402,13 @@ export function FarmingPage() {
     if (TERRAIN_PROPERTIES[terrain].harvestable) {
       if (isAdjacent) { performGather(x, y); return; }
       const path = findPathToAdjacent(currentMap, currentPos, { x, y });
-      if (path) { setMovePath(path); setQueuedAction({ type: 'gather', x, y }); setIsMoving(true); }
+      // Un chemin vide (déjà à portée) ne déclenche jamais onPathComplete : on récolte
+      // directement, sinon isMoving resterait bloqué à true (joueur figé).
+      if (path && path.length > 0) { setMovePath(path); setQueuedAction({ type: 'gather', x, y }); setIsMoving(true); }
+      else if (path) { performGather(x, y); }
     } else if (TERRAIN_PROPERTIES[terrain].traversable) {
       const path = findPath(currentMap, currentPos, { x, y });
-      if (path) { setMovePath(path); setIsMoving(true); }
+      if (path && path.length > 0) { setMovePath(path); setIsMoving(true); }
     }
   }, [performGather]);
 

--- a/apps/web/src/pages/LobbyPage.tsx
+++ b/apps/web/src/pages/LobbyPage.tsx
@@ -80,7 +80,11 @@ export function LobbyPage(): React.ReactNode {
       ]);
 
       setRooms(roomsResponse.data);
-      setIsInQueue(Boolean(queueResponse.data?.queued) && !activeSession);
+      // Ne jamais repasser isInQueue à false ici : lors d'un match le serveur retire le
+      // joueur de la file AVANT que la session soit visible. On ne quitte la recherche que
+      // sur session active (navigation) ou annulation explicite — sinon le joueur en
+      // attente perd son polling et n'est jamais envoyé dans la room.
+      setIsInQueue((prev) => prev || (Boolean(queueResponse.data?.queued) && !activeSession));
     } catch (error) {
       console.error('Failed to fetch lobby state', error);
     } finally {
@@ -209,19 +213,15 @@ export function LobbyPage(): React.ReactNode {
 
     const interval = window.setInterval(async () => {
       try {
-        const [sessionResponse, queueResponse] = await Promise.all([
-          gameSessionApi.getActiveSession(),
-          gameSessionApi.getQueueStatus(),
-        ]);
-
+        // On poll uniquement la session active : ne pas se baser sur la file pour arrêter
+        // la recherche, sinon le joueur en attente (retiré de la file au moment du match,
+        // avant que la session soit visible) perd son polling et reste bloqué dans le lobby.
+        const sessionResponse = await gameSessionApi.getActiveSession();
         if (sessionResponse.data && sessionResponse.data.status === 'ACTIVE') {
           setIsInQueue(false);
           await refreshSession({ silent: true });
           navigate('/farming');
-          return;
         }
-
-        setIsInQueue(Boolean(queueResponse.data?.queued));
       } catch (error) {
         console.error('Error polling queue/session:', error);
       }


### PR DESCRIPTION
## Contexte
Lot de bugs remontés sur **ressources / combat / farm**. Chaque correctif part d'une analyse de cause racine et est commité atomiquement.

## Correctifs

| Bug | Cause racine | Fix |
|---|---|---|
| **Perso bloqué après récolte** | `findPathToAdjacent` renvoie `[]` (truthy) quand déjà à portée → `isMoving=true` mais `onPathComplete` jamais appelé → figé jusqu'au reload | Récolte immédiate si chemin vide ; jamais d'entrée en mouvement sur un chemin de longueur 0 |
| **Flash de chargement à chaque récolte + clics avalés** | `isFarmingLoaded` dépend de `useProgress().active`, qui repasse `true` au swap de modèle 3D d'une case (à chaque récolte) → overlay plein écran (z-index 9999, sans `pointer-events:none`) qui clignote et capture les clics | L'écran de chargement ne s'affiche qu'au **premier** chargement (`hasLoadedOnce`) |
| **Modèles 3D qui disparaissent au zoom (combat)** | `CameraControls` combat sans `minZoom`/`maxZoom` → le dolly traverse le near plane | Ajout du clamp `15`/`80` (identique au farming) |
| **Caméra hub** | Orbit sur clic droit, axe vertical inversé, near/far trop serrés, type manquant | Orbit sur **clic gauche** (gated sur le seuil de drag → click-to-move préservé), axe vertical remis dans le bon sens, near/far élargis, type importé |
| **Pas de redirection après combat aléatoire** | `startQuickVsAiCombat` créait le combat **sans** `gameSessionId` (contrairement à ses jumeaux) → phase jamais réconciliée | Lien à la session active + **test unitaire** |
| **Joueur pas envoyé dans la room (matchmaking)** | Le joueur en attente, retiré de la file au moment du match, détruisait son propre polling | Le polling ne s'arrête que sur session active ou annulation |

## Vérification
- Web + API **type-clean** sur les fichiers touchés (une erreur TS pré-existante de `HubCamera` même supprimée).
- **356 tests web + 414 tests API** verts (nouveau test session inclus), hook pré-commit OK à chaque commit.
- Diff chirurgical (~150 lignes).

## À valider en live
Bugs runtime/3D/multijoueur non reproductibles en headless (API + Postgres/Redis + gameplay requis). À confirmer en jouant :
- **Caméra hub** : interprété « clic gauche » = **orbiter** (pas pan). Sens vertical ajustable d'un signe si le feel reste inversé.
- **Matchmaking** : à confirmer à 2 joueurs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)