### PR TITLE
feat(playground): banc de test combat /playground (sandbox, cibles, damage meter, builds)

### DIFF
--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -23,8 +23,10 @@ import { SseModule } from '../shared/sse/sse.module';
 import { VersionModule } from '../version/version.module';
 import { WorldModule } from '../world/world.module';
 
-// Module dev-only : banc de test /playground, jamais chargé en production.
-const devModules = process.env.ENABLE_DEBUG_ROUTES === 'true' ? [PlaygroundModule] : [];
+// Module dev-only : banc de test /playground, gaté par SHOW_DEBUG (même flag que
+// le perf HUD et les debug endpoints back+front ; côté web : VITE_SHOW_DEBUG).
+const showDebugFlag = (process.env.SHOW_DEBUG ?? '').toLowerCase().trim();
+const devModules = ['1', 'true', 'on', 'yes'].includes(showDebugFlag) ? [PlaygroundModule] : [];
 
 @Module({
   imports: [

--- a/apps/api/src/app/app.module.ts
+++ b/apps/api/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { EconomyModule } from '../economy/economy.module';
 import { GameSessionModule } from '../game-session/game-session.module';
 import { HealthModule } from '../health/health.module';
 import { HubModule } from '../hub/hub.module';
+import { PlaygroundModule } from '../playground/playground.module';
 import { PlayerModule } from '../player/player.module';
 import { PerfModule } from '../shared/perf/perf.module';
 import { RequestContextMiddleware } from '../shared/perf/request-context.middleware';
@@ -21,6 +22,9 @@ import { SecurityModule } from '../shared/security/security.module';
 import { SseModule } from '../shared/sse/sse.module';
 import { VersionModule } from '../version/version.module';
 import { WorldModule } from '../world/world.module';
+
+// Module dev-only : banc de test /playground, jamais chargé en production.
+const devModules = process.env.ENABLE_DEBUG_ROUTES === 'true' ? [PlaygroundModule] : [];
 
 @Module({
   imports: [
@@ -47,6 +51,7 @@ import { WorldModule } from '../world/world.module';
     HubModule,
     HealthModule,
     VersionModule,
+    ...devModules,
   ],
   providers: [
     {

--- a/apps/api/src/combat/map/map.service.spec.ts
+++ b/apps/api/src/combat/map/map.service.spec.ts
@@ -43,6 +43,28 @@ describe('MapService', () => {
     });
   });
 
+  describe('generateFlatMap', () => {
+    it('retourne width×height tiles', () => {
+      expect(service.generateFlatMap(5, 5)).toHaveLength(25);
+    });
+
+    it('taille par défaut 10×10', () => {
+      expect(service.generateFlatMap()).toHaveLength(100);
+    });
+
+    it('ne contient que du GROUND (aucune ressource)', () => {
+      const tiles = service.generateFlatMap(10, 10);
+      tiles.forEach((t) => expect(t.type).toBe(TerrainType.GROUND));
+    });
+
+    it('couvre chaque coordonnée une seule fois', () => {
+      const tiles = service.generateFlatMap(4, 3);
+      const keys = new Set(tiles.map((t) => `${t.x},${t.y}`));
+      expect(keys.size).toBe(12);
+      expect(tiles.every((t) => t.x >= 0 && t.x < 4 && t.y >= 0 && t.y < 3)).toBe(true);
+    });
+  });
+
   describe('getReachablePositions', () => {
     const emptyTiles = () => {
       const tiles: Array<{ x: number; y: number; type: TerrainType }> = [];

--- a/apps/api/src/combat/map/map.service.ts
+++ b/apps/api/src/combat/map/map.service.ts
@@ -37,6 +37,22 @@ export class MapService {
   }
 
   /**
+   * Génère une carte de combat entièrement vide (que du sol), sans ressource ni
+   * obstacle. Utilisée par le playground où le développeur peint lui-même les cases.
+   */
+  generateFlatMap(width = 10, height = 10): Tile[] {
+    const tiles: Tile[] = [];
+
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        tiles.push({ x, y, type: TerrainType.GROUND });
+      }
+    }
+
+    return tiles;
+  }
+
+  /**
    * Retourne les positions atteignables pour pré-visualisation front.
    */
   getReachablePositions(

--- a/apps/api/src/combat/session/session.service.ts
+++ b/apps/api/src/combat/session/session.service.ts
@@ -286,6 +286,22 @@ export class SessionService {
     await Promise.all(open.map((s) => this.redis.del(`combat:${s.id}`)));
   }
 
+  /**
+   * Passe du bac à sable à un vrai combat tour-par-tour vs IA : ferme le combat
+   * playground ouvert puis lance un combat normal (IA mobile + PV finis, sans le
+   * flag isPlayground → système de tour et PA/PM normaux).
+   */
+  async startPlaygroundRealCombat(humanId: string): Promise<CombatState> {
+    const bot = await this.getOrCreateBot();
+    await this.closeOpenPublicSessions(humanId, bot.id);
+
+    const session = await this.prisma.combatSession.create({
+      data: { player1Id: humanId, player2Id: bot.id, status: 'WAITING' },
+    });
+
+    return this.accept(session.id, bot.id);
+  }
+
   private async buildPlaygroundState(
     sessionId: string,
     humanId: string,

--- a/apps/api/src/combat/session/session.service.ts
+++ b/apps/api/src/combat/session/session.service.ts
@@ -2,7 +2,7 @@ import { performance } from 'node:perf_hooks';
 
 import { calculateInitiativeJet } from '@game/game-engine';
 import { EquipmentSlotType, GAME_EVENTS } from '@game/shared-types';
-import type { CombatState } from '@game/shared-types';
+import type { CombatState, CombatPlayer, PlayerStats } from '@game/shared-types';
 import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
 import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
 
@@ -16,6 +16,12 @@ import { SessionSecurityService } from '../../shared/security/session-security.s
 import { SseTicketService } from '../../shared/security/sse-ticket.service';
 import { SseService } from '../../shared/sse/sse.service';
 import { MapService } from '../map/map.service';
+
+/** PV du mannequin de playground : assez grand pour ne jamais tomber à 0. */
+const PLAYGROUND_DUMMY_VIT = 999_999;
+
+/** PA/PM du joueur en playground : grande réserve + jamais décrémentée (cf. TurnService). */
+const PLAYGROUND_AP = 99;
 
 @Injectable()
 export class SessionService {
@@ -218,11 +224,7 @@ export class SessionService {
       },
     };
 
-    await this.redis.setJson(`combat:${sessionId}`, initialState, 3600);
-
-    this.sse.emit(sessionId, 'STATE_UPDATED', initialState);
-    this.sse.emit(sessionId, 'TURN_STARTED', { playerId: firstPlayerId });
-    this.eventEmitter.emit(GAME_EVENTS.TURN_STARTED, { sessionId, playerId: firstPlayerId });
+    await this.commitInitialState(sessionId, initialState, firstPlayerId);
 
     this.perfLogger.logDuration('combat', 'session.accept', performance.now() - startedAt, {
       session_id: sessionId,
@@ -231,6 +233,177 @@ export class SessionService {
     });
 
     return initialState;
+  }
+
+  private async commitInitialState(
+    sessionId: string,
+    state: CombatState,
+    firstPlayerId: string,
+  ): Promise<void> {
+    await this.redis.setJson(`combat:${sessionId}`, state, 3600);
+    this.sse.emit(sessionId, 'STATE_UPDATED', state);
+    this.sse.emit(sessionId, 'TURN_STARTED', { playerId: firstPlayerId });
+    this.eventEmitter.emit(GAME_EVENTS.TURN_STARTED, { sessionId, playerId: firstPlayerId });
+  }
+
+  /**
+   * Démarre un combat « banc de test » : adversaire = mannequin immobile à PV
+   * quasi-illimités (le combat ne se termine jamais). Le joueur garde ses sorts
+   * issus de son équipement courant.
+   */
+  async startPlaygroundCombat(humanId: string): Promise<CombatState> {
+    const bot = await this.getOrCreateBot();
+    // Index unique partiel sur combat public (gameSessionId null) : un seul ouvert
+    // par player1 ET par player2. Le mannequin partagé (bot) est player2 et le
+    // combat playground ne se termine jamais → on referme tout combat public ouvert
+    // impliquant le joueur ou le bot avant d'en relancer un neuf.
+    await this.closeOpenPublicSessions(humanId, bot.id);
+
+    const session = await this.prisma.combatSession.create({
+      data: { player1Id: humanId, player2Id: bot.id, status: 'ACTIVE' },
+    });
+
+    const state = await this.buildPlaygroundState(session.id, humanId, bot.id);
+    await this.commitInitialState(session.id, state, humanId);
+    return state;
+  }
+
+  private async closeOpenPublicSessions(humanId: string, botId: string): Promise<void> {
+    const open = await this.prisma.combatSession.findMany({
+      where: {
+        gameSessionId: null,
+        status: { in: ['WAITING', 'ACTIVE'] },
+        OR: [{ player1Id: humanId }, { player2Id: botId }],
+      },
+      select: { id: true },
+    });
+    if (open.length === 0) return;
+
+    await this.prisma.combatSession.updateMany({
+      where: { id: { in: open.map((s) => s.id) } },
+      data: { status: 'FINISHED', endedAt: new Date() },
+    });
+    await Promise.all(open.map((s) => this.redis.del(`combat:${s.id}`)));
+  }
+
+  private async buildPlaygroundState(
+    sessionId: string,
+    humanId: string,
+    botId: string,
+  ): Promise<CombatState> {
+    const [loadout, spells, human, bot] = await Promise.all([
+      this.playerStatsService.getCombatLoadout(humanId),
+      this.playerSpellProjection.getCombatSpellDefinitions(humanId),
+      this.prisma.player.findUnique({
+        where: { id: humanId },
+        select: { username: true, skin: true },
+      }),
+      this.prisma.player.findUnique({
+        where: { id: botId },
+        select: { username: true, skin: true },
+      }),
+    ]);
+
+    const humanStats: PlayerStats = { ...loadout.stats, pa: PLAYGROUND_AP, pm: PLAYGROUND_AP };
+
+    return {
+      sessionId,
+      currentTurnPlayerId: humanId,
+      turnNumber: 1,
+      isPlayground: true,
+      players: {
+        [humanId]: {
+          playerId: humanId,
+          username: human?.username || 'Joueur',
+          type: 'PLAYER',
+          stats: humanStats,
+          currentVit: humanStats.vit,
+          position: { x: 1, y: 1 },
+          spells,
+          remainingPa: PLAYGROUND_AP,
+          remainingPm: PLAYGROUND_AP,
+          spellCooldowns: {},
+          buffs: [],
+          skin: human?.skin || 'soldier-classic',
+          items: loadout.items,
+        },
+        [botId]: this.buildPlaygroundDummy(botId, bot?.username, bot?.skin),
+      },
+      map: {
+        width: 10,
+        height: 10,
+        tiles: this.mapService.generateFlatMap(10, 10),
+      },
+    };
+  }
+
+  /**
+   * Mannequin : `spells:[]` + `pm:0` ⇒ l'IA (BotService) ne peut que passer son
+   * tour (ni sort, ni déplacement) ; `currentVit` énorme ⇒ ne meurt jamais.
+   */
+  private buildPlaygroundDummy(botId: string, username?: string, skin?: string): CombatPlayer {
+    const stats: PlayerStats = {
+      vit: PLAYGROUND_DUMMY_VIT,
+      atk: 0,
+      mag: 0,
+      def: 0,
+      res: 0,
+      ini: 0,
+      pa: 0,
+      pm: 0,
+      baseVit: PLAYGROUND_DUMMY_VIT,
+      baseAtk: 0,
+      baseMag: 0,
+      baseDef: 0,
+      baseRes: 0,
+      baseIni: 0,
+      basePa: 0,
+      basePm: 0,
+    };
+
+    return {
+      playerId: botId,
+      username: username || 'Bot',
+      type: 'PLAYER',
+      stats,
+      currentVit: PLAYGROUND_DUMMY_VIT,
+      position: { x: 8, y: 8 },
+      spells: [],
+      remainingPa: 0,
+      remainingPm: 0,
+      spellCooldowns: {},
+      buffs: [],
+      skin: skin || 'orc-classic',
+    };
+  }
+
+  /**
+   * Re-snapshot des stats/sorts du joueur dans le combat playground en cours,
+   * après un changement d'équipement, sans redémarrer le combat.
+   */
+  async refreshPlaygroundLoadout(sessionId: string, humanId: string): Promise<CombatState> {
+    const state = await this.redis.getJson<CombatState>(`combat:${sessionId}`);
+    if (!state) throw new BadRequestException('Session de playground introuvable');
+
+    const human = state.players[humanId];
+    if (!human) throw new BadRequestException('Joueur introuvable dans la session');
+
+    const [loadout, spells] = await Promise.all([
+      this.playerStatsService.getCombatLoadout(humanId),
+      this.playerSpellProjection.getCombatSpellDefinitions(humanId),
+    ]);
+
+    // PA/PM restent illimités quel que soit l'équipement (banc de test).
+    human.stats = { ...loadout.stats, pa: PLAYGROUND_AP, pm: PLAYGROUND_AP };
+    human.spells = spells;
+    human.items = loadout.items;
+    human.currentVit = loadout.stats.vit;
+    human.remainingPa = PLAYGROUND_AP;
+    human.remainingPm = PLAYGROUND_AP;
+
+    await this.redis.setJson(`combat:${sessionId}`, state, 3600);
+    this.sse.emit(sessionId, 'STATE_UPDATED', state);
+    return state;
   }
 
   @OnEvent(GAME_EVENTS.COMBAT_ENDED)

--- a/apps/api/src/combat/session/session.service.ts
+++ b/apps/api/src/combat/session/session.service.ts
@@ -327,6 +327,7 @@ export class SessionService {
       currentTurnPlayerId: humanId,
       turnNumber: 1,
       isPlayground: true,
+      noCooldown: true,
       players: {
         [humanId]: {
           playerId: humanId,
@@ -335,6 +336,7 @@ export class SessionService {
           stats: humanStats,
           currentVit: humanStats.vit,
           position: { x: 1, y: 1 },
+          spawn: { x: 1, y: 1 },
           spells,
           remainingPa: PLAYGROUND_AP,
           remainingPm: PLAYGROUND_AP,
@@ -384,6 +386,7 @@ export class SessionService {
       stats,
       currentVit: PLAYGROUND_DUMMY_VIT,
       position: { x: 8, y: 8 },
+      spawn: { x: 8, y: 8 },
       spells: [],
       remainingPa: 0,
       remainingPm: 0,

--- a/apps/api/src/combat/turn/combat-watchdog.service.ts
+++ b/apps/api/src/combat/turn/combat-watchdog.service.ts
@@ -76,6 +76,8 @@ export class CombatWatchdogService {
       try {
         const state = await this.redis.getJson<CombatState & { lastActionAt?: number }>(key);
         if (!state || state.winnerId) continue;
+        // Bac à sable /playground : pas de système de tour, jamais de force END_TURN.
+        if (state.isPlayground) continue;
 
         const lastActionAt = state.lastActionAt ?? 0;
         if (lastActionAt === 0) continue; // pas encore tracké

--- a/apps/api/src/combat/turn/turn.service.ts
+++ b/apps/api/src/combat/turn/turn.service.ts
@@ -273,7 +273,7 @@ export class TurnService {
       throw new BadRequestException('PA insuffisants');
     }
 
-    if (player.spellCooldowns[spell.id] > 0) {
+    if (!state.noCooldown && player.spellCooldowns[spell.id] > 0) {
       throw new BadRequestException('Sort encore en cooldown');
     }
 
@@ -303,7 +303,7 @@ export class TurnService {
     if (!state.isPlayground) {
       player.remainingPa -= spell.paCost;
     }
-    if (spell.cooldown > 0) {
+    if (spell.cooldown > 0 && !state.noCooldown) {
       player.spellCooldowns[spell.id] = spell.cooldown;
     }
 
@@ -328,6 +328,8 @@ export class TurnService {
   }
 
   private async checkVictory(state: CombatState) {
+    // Bac à sable : aucune fin de combat (mannequins encaissent sans verrouiller la session).
+    if (state.isPlayground) return false;
     const players = Object.values(state.players).filter((p) => p.type === 'PLAYER');
     for (const player of players) {
       if (player.currentVit <= 0) {

--- a/apps/api/src/combat/turn/turn.service.ts
+++ b/apps/api/src/combat/turn/turn.service.ts
@@ -217,7 +217,9 @@ export class TurnService {
     const distance =
       Math.abs(target.x - player.position.x) + Math.abs(target.y - player.position.y);
     player.position = target;
-    player.remainingPm -= distance;
+    if (!state.isPlayground) {
+      player.remainingPm -= distance;
+    }
 
     return state;
   }
@@ -242,7 +244,9 @@ export class TurnService {
 
     const from = { ...player.position };
     player.position = target;
-    player.remainingPm -= 1;
+    if (!state.isPlayground) {
+      player.remainingPm -= 1;
+    }
 
     this.sse.emit(state.sessionId, 'PLAYER_JUMPED', {
       playerId: player.playerId,
@@ -265,7 +269,7 @@ export class TurnService {
       throw new BadRequestException('Sort introuvable');
     }
 
-    if (player.remainingPa < spell.paCost) {
+    if (!state.isPlayground && player.remainingPa < spell.paCost) {
       throw new BadRequestException('PA insuffisants');
     }
 
@@ -296,7 +300,9 @@ export class TurnService {
       this.sse.emit(state.sessionId, event.type, event.payload);
     }
 
-    player.remainingPa -= spell.paCost;
+    if (!state.isPlayground) {
+      player.remainingPa -= spell.paCost;
+    }
     if (spell.cooldown > 0) {
       player.spellCooldowns[spell.id] = spell.cooldown;
     }

--- a/apps/api/src/playground/dto/playground.dto.ts
+++ b/apps/api/src/playground/dto/playground.dto.ts
@@ -1,0 +1,39 @@
+import { EquipmentSlotType, TerrainType } from '@game/shared-types';
+import { IsEnum, IsInt, IsNotEmpty, IsString, Min } from 'class-validator';
+
+export class PaintTileDto {
+  @IsInt()
+  @Min(0)
+  x!: number;
+
+  @IsInt()
+  @Min(0)
+  y!: number;
+
+  @IsEnum(TerrainType)
+  terrain!: TerrainType;
+}
+
+export class GatherTileDto {
+  @IsInt()
+  @Min(0)
+  x!: number;
+
+  @IsInt()
+  @Min(0)
+  y!: number;
+}
+
+export class GrantEquipDto {
+  @IsString()
+  @IsNotEmpty()
+  itemId!: string;
+
+  @IsEnum(EquipmentSlotType)
+  slot!: EquipmentSlotType;
+}
+
+export class UnequipDto {
+  @IsEnum(EquipmentSlotType)
+  slot!: EquipmentSlotType;
+}

--- a/apps/api/src/playground/dto/playground.dto.ts
+++ b/apps/api/src/playground/dto/playground.dto.ts
@@ -1,5 +1,14 @@
 import { EquipmentSlotType, TerrainType } from '@game/shared-types';
-import { IsEnum, IsInt, IsNotEmpty, IsString, Min } from 'class-validator';
+import {
+  IsBoolean,
+  IsEnum,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+} from 'class-validator';
 
 export class PaintTileDto {
   @IsInt()
@@ -36,4 +45,75 @@ export class GrantEquipDto {
 export class UnequipDto {
   @IsEnum(EquipmentSlotType)
   slot!: EquipmentSlotType;
+}
+
+export class AddDummyDto {
+  @IsInt()
+  @Min(0)
+  x!: number;
+
+  @IsInt()
+  @Min(0)
+  y!: number;
+}
+
+export class SetDummyDto {
+  @IsString()
+  @IsNotEmpty()
+  dummyId!: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(9_999_999)
+  vit?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(1000)
+  def?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(1000)
+  res?: number;
+}
+
+export class SetPlayerStatsDto {
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(9_999_999)
+  vit?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(1000)
+  atk?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(1000)
+  mag?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(1000)
+  def?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(1000)
+  res?: number;
+}
+
+export class NoCooldownDto {
+  @IsBoolean()
+  enabled!: boolean;
 }

--- a/apps/api/src/playground/playground.controller.ts
+++ b/apps/api/src/playground/playground.controller.ts
@@ -1,8 +1,17 @@
-import { Body, Controller, Param, Post, Request, UseGuards } from '@nestjs/common';
+import { Body, Controller, Delete, Param, Patch, Post, Request, UseGuards } from '@nestjs/common';
 
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
-import { GatherTileDto, GrantEquipDto, PaintTileDto, UnequipDto } from './dto/playground.dto';
+import {
+  AddDummyDto,
+  GatherTileDto,
+  GrantEquipDto,
+  NoCooldownDto,
+  PaintTileDto,
+  SetDummyDto,
+  SetPlayerStatsDto,
+  UnequipDto,
+} from './dto/playground.dto';
 import { PlaygroundService } from './playground.service';
 
 @UseGuards(JwtAuthGuard)
@@ -54,5 +63,58 @@ export class PlaygroundController {
     @Request() req: { user: { id: string } },
   ) {
     return this.playground.unequip(req.user.id, sessionId, dto);
+  }
+
+  @Post(':sessionId/dummy')
+  addDummy(
+    @Param('sessionId') sessionId: string,
+    @Body() dto: AddDummyDto,
+    @Request() req: { user: { id: string } },
+  ) {
+    return this.playground.addDummy(req.user.id, sessionId, dto);
+  }
+
+  @Patch(':sessionId/dummy')
+  setDummy(
+    @Param('sessionId') sessionId: string,
+    @Body() dto: SetDummyDto,
+    @Request() req: { user: { id: string } },
+  ) {
+    return this.playground.setDummy(req.user.id, sessionId, dto);
+  }
+
+  @Delete(':sessionId/dummy/:dummyId')
+  removeDummy(
+    @Param('sessionId') sessionId: string,
+    @Param('dummyId') dummyId: string,
+    @Request() req: { user: { id: string } },
+  ) {
+    return this.playground.removeDummy(req.user.id, sessionId, dummyId);
+  }
+
+  @Post(':sessionId/dummy/reset')
+  resetDummies(
+    @Param('sessionId') sessionId: string,
+    @Request() req: { user: { id: string } },
+  ) {
+    return this.playground.resetDummies(req.user.id, sessionId);
+  }
+
+  @Post(':sessionId/player-stats')
+  setPlayerStats(
+    @Param('sessionId') sessionId: string,
+    @Body() dto: SetPlayerStatsDto,
+    @Request() req: { user: { id: string } },
+  ) {
+    return this.playground.setPlayerStats(req.user.id, sessionId, dto);
+  }
+
+  @Post(':sessionId/no-cooldown')
+  setNoCooldown(
+    @Param('sessionId') sessionId: string,
+    @Body() dto: NoCooldownDto,
+    @Request() req: { user: { id: string } },
+  ) {
+    return this.playground.setNoCooldown(req.user.id, sessionId, dto);
   }
 }

--- a/apps/api/src/playground/playground.controller.ts
+++ b/apps/api/src/playground/playground.controller.ts
@@ -15,6 +15,11 @@ export class PlaygroundController {
     return this.playground.start(req.user.id);
   }
 
+  @Post('combat')
+  startCombat(@Request() req: { user: { id: string } }) {
+    return this.playground.startCombat(req.user.id);
+  }
+
   @Post(':sessionId/paint')
   paint(
     @Param('sessionId') sessionId: string,

--- a/apps/api/src/playground/playground.controller.ts
+++ b/apps/api/src/playground/playground.controller.ts
@@ -1,0 +1,53 @@
+import { Body, Controller, Param, Post, Request, UseGuards } from '@nestjs/common';
+
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+import { GatherTileDto, GrantEquipDto, PaintTileDto, UnequipDto } from './dto/playground.dto';
+import { PlaygroundService } from './playground.service';
+
+@UseGuards(JwtAuthGuard)
+@Controller('playground')
+export class PlaygroundController {
+  constructor(private readonly playground: PlaygroundService) {}
+
+  @Post('start')
+  start(@Request() req: { user: { id: string } }) {
+    return this.playground.start(req.user.id);
+  }
+
+  @Post(':sessionId/paint')
+  paint(
+    @Param('sessionId') sessionId: string,
+    @Body() dto: PaintTileDto,
+    @Request() req: { user: { id: string } },
+  ) {
+    return this.playground.paintTile(req.user.id, sessionId, dto);
+  }
+
+  @Post(':sessionId/gather')
+  gather(
+    @Param('sessionId') sessionId: string,
+    @Body() dto: GatherTileDto,
+    @Request() req: { user: { id: string } },
+  ) {
+    return this.playground.gatherTile(req.user.id, sessionId, dto);
+  }
+
+  @Post(':sessionId/grant-equip')
+  grantEquip(
+    @Param('sessionId') sessionId: string,
+    @Body() dto: GrantEquipDto,
+    @Request() req: { user: { id: string } },
+  ) {
+    return this.playground.grantAndEquip(req.user.id, sessionId, dto);
+  }
+
+  @Post(':sessionId/unequip')
+  unequip(
+    @Param('sessionId') sessionId: string,
+    @Body() dto: UnequipDto,
+    @Request() req: { user: { id: string } },
+  ) {
+    return this.playground.unequip(req.user.id, sessionId, dto);
+  }
+}

--- a/apps/api/src/playground/playground.module.ts
+++ b/apps/api/src/playground/playground.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+
+import { CombatModule } from '../combat/combat.module';
+import { EconomyModule } from '../economy/economy.module';
+import { PrismaModule } from '../shared/prisma/prisma.module';
+import { RedisModule } from '../shared/redis/redis.module';
+import { SseModule } from '../shared/sse/sse.module';
+
+import { PlaygroundController } from './playground.controller';
+import { PlaygroundService } from './playground.service';
+
+/**
+ * Module dev-only (banc de test /playground). Importé dans AppModule uniquement
+ * quand ENABLE_DEBUG_ROUTES=true. Orchestre Combat + Economy via leurs services
+ * exportés (SessionService, EquipmentService, InventoryService).
+ */
+@Module({
+  imports: [CombatModule, EconomyModule, PrismaModule, RedisModule, SseModule],
+  controllers: [PlaygroundController],
+  providers: [PlaygroundService],
+})
+export class PlaygroundModule {}

--- a/apps/api/src/playground/playground.module.ts
+++ b/apps/api/src/playground/playground.module.ts
@@ -11,7 +11,7 @@ import { PlaygroundService } from './playground.service';
 
 /**
  * Module dev-only (banc de test /playground). Importé dans AppModule uniquement
- * quand ENABLE_DEBUG_ROUTES=true. Orchestre Combat + Economy via leurs services
+ * quand SHOW_DEBUG est actif. Orchestre Combat + Economy via leurs services
  * exportés (SessionService, EquipmentService, InventoryService).
  */
 @Module({

--- a/apps/api/src/playground/playground.service.spec.ts
+++ b/apps/api/src/playground/playground.service.spec.ts
@@ -1,0 +1,118 @@
+import type { CombatState } from '@game/shared-types';
+import { TerrainType } from '@game/shared-types';
+import { BadRequestException } from '@nestjs/common';
+
+import { PlaygroundService } from './playground.service';
+
+type Mocked = Record<string, jest.Mock>;
+
+function makeState(): CombatState {
+  return {
+    sessionId: 'sess-1',
+    currentTurnPlayerId: 'human',
+    turnNumber: 1,
+    isPlayground: true,
+    players: {},
+    map: {
+      width: 2,
+      height: 2,
+      tiles: [
+        { x: 0, y: 0, type: TerrainType.GROUND },
+        { x: 1, y: 0, type: TerrainType.GROUND },
+        { x: 0, y: 1, type: TerrainType.GROUND },
+        { x: 1, y: 1, type: TerrainType.WOOD },
+      ],
+    },
+  };
+}
+
+describe('PlaygroundService', () => {
+  let service: PlaygroundService;
+  let session: Mocked;
+  let equipment: Mocked;
+  let inventory: Mocked;
+  let redis: Mocked;
+  let sse: Mocked;
+  let prisma: { item: Mocked; inventoryItem: Mocked };
+  let state: CombatState;
+
+  beforeEach(() => {
+    state = makeState();
+    session = {
+      startPlaygroundCombat: jest.fn(),
+      getStateForParticipant: jest.fn().mockResolvedValue(state),
+      refreshPlaygroundLoadout: jest.fn(),
+    };
+    equipment = { equip: jest.fn(), unequip: jest.fn() };
+    inventory = { addResourceByName: jest.fn() };
+    redis = { setJson: jest.fn() };
+    sse = { emit: jest.fn() };
+    prisma = {
+      item: { findUnique: jest.fn() },
+      inventoryItem: { findFirst: jest.fn(), create: jest.fn() },
+    };
+
+    service = new PlaygroundService(
+      session as never,
+      equipment as never,
+      inventory as never,
+      redis as never,
+      sse as never,
+      prisma as never,
+    );
+  });
+
+  describe('paintTile', () => {
+    it('change le type de la case et diffuse STATE_UPDATED', async () => {
+      const result = await service.paintTile('human', 'sess-1', {
+        x: 0,
+        y: 0,
+        terrain: TerrainType.IRON,
+      });
+
+      expect(result.map.tiles.find((t) => t.x === 0 && t.y === 0)?.type).toBe(TerrainType.IRON);
+      expect(redis.setJson).toHaveBeenCalledWith('combat:sess-1', state, 3600);
+      expect(sse.emit).toHaveBeenCalledWith('sess-1', 'STATE_UPDATED', state);
+    });
+
+    it('rejette une case introuvable', async () => {
+      await expect(
+        service.paintTile('human', 'sess-1', { x: 9, y: 9, terrain: TerrainType.IRON }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+    });
+  });
+
+  describe('gatherTile', () => {
+    it('récolte un node, l’ajoute à l’inventaire et repasse la case en sol', async () => {
+      const result = await service.gatherTile('human', 'sess-1', { x: 1, y: 1 });
+
+      expect(inventory.addResourceByName).toHaveBeenCalledWith('human', 'Bois');
+      expect(result.map.tiles.find((t) => t.x === 1 && t.y === 1)?.type).toBe(TerrainType.GROUND);
+      expect(sse.emit).toHaveBeenCalledWith('sess-1', 'STATE_UPDATED', state);
+    });
+
+    it('rejette une case non récoltable', async () => {
+      await expect(
+        service.gatherTile('human', 'sess-1', { x: 0, y: 0 }),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(inventory.addResourceByName).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('grantAndEquip', () => {
+    it('crée l’objet en inventaire, l’équipe puis rafraîchit le loadout', async () => {
+      prisma.item.findUnique.mockResolvedValue({ id: 'item-1', type: 'ACCESSORY' });
+      prisma.inventoryItem.findFirst.mockResolvedValue(null);
+      prisma.inventoryItem.create.mockResolvedValue({ id: 'inv-1' });
+      session.refreshPlaygroundLoadout.mockResolvedValue(state);
+
+      await service.grantAndEquip('human', 'sess-1', {
+        itemId: 'item-1',
+        slot: 'ACCESSORY' as never,
+      });
+
+      expect(equipment.equip).toHaveBeenCalledWith('human', 'inv-1', 'ACCESSORY');
+      expect(session.refreshPlaygroundLoadout).toHaveBeenCalledWith('sess-1', 'human');
+    });
+  });
+});

--- a/apps/api/src/playground/playground.service.ts
+++ b/apps/api/src/playground/playground.service.ts
@@ -30,8 +30,13 @@ export class PlaygroundService {
   ) {}
 
   async start(humanId: string): Promise<CombatState> {
-    this.logger.log(`Démarrage d'un combat playground pour ${humanId}`);
+    this.logger.log(`Démarrage d'un bac à sable playground pour ${humanId}`);
     return this.session.startPlaygroundCombat(humanId);
+  }
+
+  async startCombat(humanId: string): Promise<CombatState> {
+    this.logger.log(`Passage en mode combat (vs IA) pour ${humanId}`);
+    return this.session.startPlaygroundRealCombat(humanId);
   }
 
   async paintTile(humanId: string, sessionId: string, dto: PaintTileDto): Promise<CombatState> {

--- a/apps/api/src/playground/playground.service.ts
+++ b/apps/api/src/playground/playground.service.ts
@@ -1,0 +1,95 @@
+import type { CombatState } from '@game/shared-types';
+import { TERRAIN_PROPERTIES, TerrainType } from '@game/shared-types';
+import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+
+import { EquipmentService } from '../economy/equipment/equipment.service';
+import { InventoryService } from '../economy/inventory/inventory.service';
+import { SessionService } from '../combat/session/session.service';
+import { PrismaService } from '../shared/prisma/prisma.service';
+import { RedisService } from '../shared/redis/redis.service';
+import { SseService } from '../shared/sse/sse.service';
+
+import { GatherTileDto, GrantEquipDto, PaintTileDto, UnequipDto } from './dto/playground.dto';
+
+/**
+ * Orchestrateur dev-only (route /playground). Composition-root assumée qui relie
+ * Combat + Economy : ce module n'est ni l'un ni l'autre, il ne viole donc pas la
+ * règle de découplage Combat↔Economy. Chargé uniquement si ENABLE_DEBUG_ROUTES.
+ */
+@Injectable()
+export class PlaygroundService {
+  private readonly logger = new Logger(PlaygroundService.name);
+
+  constructor(
+    private readonly session: SessionService,
+    private readonly equipment: EquipmentService,
+    private readonly inventory: InventoryService,
+    private readonly redis: RedisService,
+    private readonly sse: SseService,
+    private readonly prisma: PrismaService,
+  ) {}
+
+  async start(humanId: string): Promise<CombatState> {
+    this.logger.log(`Démarrage d'un combat playground pour ${humanId}`);
+    return this.session.startPlaygroundCombat(humanId);
+  }
+
+  async paintTile(humanId: string, sessionId: string, dto: PaintTileDto): Promise<CombatState> {
+    const state = await this.session.getStateForParticipant(sessionId, humanId);
+    const tile = state.map.tiles.find((t) => t.x === dto.x && t.y === dto.y);
+    if (!tile) throw new BadRequestException('Case introuvable');
+
+    tile.type = dto.terrain;
+    return this.persistAndBroadcast(sessionId, state);
+  }
+
+  async gatherTile(humanId: string, sessionId: string, dto: GatherTileDto): Promise<CombatState> {
+    const state = await this.session.getStateForParticipant(sessionId, humanId);
+    const tile = state.map.tiles.find((t) => t.x === dto.x && t.y === dto.y);
+    if (!tile) throw new BadRequestException('Case introuvable');
+
+    const props = TERRAIN_PROPERTIES[tile.type];
+    if (!props?.harvestable || !props.resourceName) {
+      throw new BadRequestException('Ressource non récoltable');
+    }
+
+    await this.inventory.addResourceByName(humanId, props.resourceName);
+    tile.type = TerrainType.GROUND;
+    return this.persistAndBroadcast(sessionId, state);
+  }
+
+  async grantAndEquip(
+    humanId: string,
+    sessionId: string,
+    dto: GrantEquipDto,
+  ): Promise<CombatState> {
+    const item = await this.prisma.item.findUnique({ where: { id: dto.itemId } });
+    if (!item) throw new NotFoundException('Objet introuvable');
+
+    const inventoryItem = await this.findOrCreateInventoryItem(humanId, dto.itemId);
+    await this.equipment.equip(humanId, inventoryItem.id, dto.slot);
+    return this.session.refreshPlaygroundLoadout(sessionId, humanId);
+  }
+
+  async unequip(humanId: string, sessionId: string, dto: UnequipDto): Promise<CombatState> {
+    await this.equipment.unequip(humanId, dto.slot);
+    return this.session.refreshPlaygroundLoadout(sessionId, humanId);
+  }
+
+  private async findOrCreateInventoryItem(humanId: string, itemId: string) {
+    const existing = await this.prisma.inventoryItem.findFirst({
+      where: { playerId: humanId, itemId, equipmentSlot: { is: null } },
+    });
+    if (existing) return existing;
+
+    return this.prisma.inventoryItem.create({
+      data: { playerId: humanId, itemId, quantity: 1, rank: 1 },
+    });
+  }
+
+  private async persistAndBroadcast(sessionId: string, state: CombatState): Promise<CombatState> {
+    await this.redis.setJson(`combat:${sessionId}`, state, 3600);
+    this.sse.emit(sessionId, 'STATE_UPDATED', state);
+    return state;
+  }
+}

--- a/apps/api/src/playground/playground.service.ts
+++ b/apps/api/src/playground/playground.service.ts
@@ -71,7 +71,7 @@ function buildTargetDummy(
 /**
  * Orchestrateur dev-only (route /playground). Composition-root assumée qui relie
  * Combat + Economy : ce module n'est ni l'un ni l'autre, il ne viole donc pas la
- * règle de découplage Combat↔Economy. Chargé uniquement si ENABLE_DEBUG_ROUTES.
+ * règle de découplage Combat↔Economy. Chargé uniquement si SHOW_DEBUG est actif.
  */
 @Injectable()
 export class PlaygroundService {

--- a/apps/api/src/playground/playground.service.ts
+++ b/apps/api/src/playground/playground.service.ts
@@ -1,4 +1,6 @@
-import type { CombatState } from '@game/shared-types';
+import { randomUUID } from 'node:crypto';
+
+import type { CombatPlayer, CombatState, PlayerStats } from '@game/shared-types';
 import { TERRAIN_PROPERTIES, TerrainType } from '@game/shared-types';
 import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 
@@ -9,7 +11,62 @@ import { PrismaService } from '../shared/prisma/prisma.service';
 import { RedisService } from '../shared/redis/redis.service';
 import { SseService } from '../shared/sse/sse.service';
 
-import { GatherTileDto, GrantEquipDto, PaintTileDto, UnequipDto } from './dto/playground.dto';
+import {
+  AddDummyDto,
+  GatherTileDto,
+  GrantEquipDto,
+  NoCooldownDto,
+  PaintTileDto,
+  SetDummyDto,
+  SetPlayerStatsDto,
+  UnequipDto,
+} from './dto/playground.dto';
+
+/** PV par défaut d'un mannequin-cible ajouté (cible « réaliste », finie). */
+const DEFAULT_TARGET_VIT = 1000;
+
+function buildTargetDummy(
+  id: string,
+  x: number,
+  y: number,
+  vit: number,
+  def: number,
+  res: number,
+): CombatPlayer {
+  const stats: PlayerStats = {
+    vit,
+    atk: 0,
+    mag: 0,
+    def,
+    res,
+    ini: 0,
+    pa: 0,
+    pm: 0,
+    baseVit: vit,
+    baseAtk: 0,
+    baseMag: 0,
+    baseDef: def,
+    baseRes: res,
+    baseIni: 0,
+    basePa: 0,
+    basePm: 0,
+  };
+  return {
+    playerId: id,
+    username: 'Bot cible',
+    type: 'PLAYER',
+    stats,
+    currentVit: vit,
+    position: { x, y },
+    spawn: { x, y },
+    spells: [],
+    remainingPa: 0,
+    remainingPm: 0,
+    spellCooldowns: {},
+    buffs: [],
+    skin: 'orc-classic',
+  };
+}
 
 /**
  * Orchestrateur dev-only (route /playground). Composition-root assumée qui relie
@@ -79,6 +136,84 @@ export class PlaygroundService {
   async unequip(humanId: string, sessionId: string, dto: UnequipDto): Promise<CombatState> {
     await this.equipment.unequip(humanId, dto.slot);
     return this.session.refreshPlaygroundLoadout(sessionId, humanId);
+  }
+
+  async addDummy(humanId: string, sessionId: string, dto: AddDummyDto): Promise<CombatState> {
+    const state = await this.session.getStateForParticipant(sessionId, humanId);
+    const id = `dummy-${randomUUID()}`;
+    state.players[id] = buildTargetDummy(id, dto.x, dto.y, DEFAULT_TARGET_VIT, 0, 0);
+    return this.persistAndBroadcast(sessionId, state);
+  }
+
+  async setDummy(humanId: string, sessionId: string, dto: SetDummyDto): Promise<CombatState> {
+    const state = await this.session.getStateForParticipant(sessionId, humanId);
+    const dummy = this.getDummy(state, humanId, dto.dummyId);
+
+    if (dto.def !== undefined) dummy.stats.def = dummy.stats.baseDef = dto.def;
+    if (dto.res !== undefined) dummy.stats.res = dummy.stats.baseRes = dto.res;
+    if (dto.vit !== undefined) {
+      dummy.stats.vit = dummy.stats.baseVit = dto.vit;
+      dummy.currentVit = dto.vit;
+    }
+    return this.persistAndBroadcast(sessionId, state);
+  }
+
+  async removeDummy(humanId: string, sessionId: string, dummyId: string): Promise<CombatState> {
+    const state = await this.session.getStateForParticipant(sessionId, humanId);
+    this.getDummy(state, humanId, dummyId);
+    delete state.players[dummyId];
+    return this.persistAndBroadcast(sessionId, state);
+  }
+
+  async resetDummies(humanId: string, sessionId: string): Promise<CombatState> {
+    const state = await this.session.getStateForParticipant(sessionId, humanId);
+    for (const player of Object.values(state.players)) {
+      if (player.playerId === humanId) continue;
+      player.currentVit = player.stats.vit;
+      if (player.spawn) player.position = { ...player.spawn };
+      player.buffs = [];
+      player.spellCooldowns = {};
+    }
+    return this.persistAndBroadcast(sessionId, state);
+  }
+
+  async setPlayerStats(
+    humanId: string,
+    sessionId: string,
+    dto: SetPlayerStatsDto,
+  ): Promise<CombatState> {
+    const state = await this.session.getStateForParticipant(sessionId, humanId);
+    const player = state.players[humanId];
+    if (!player) throw new BadRequestException('Joueur introuvable');
+
+    const stats = player.stats;
+    if (dto.atk !== undefined) stats.atk = stats.baseAtk = dto.atk;
+    if (dto.mag !== undefined) stats.mag = stats.baseMag = dto.mag;
+    if (dto.def !== undefined) stats.def = stats.baseDef = dto.def;
+    if (dto.res !== undefined) stats.res = stats.baseRes = dto.res;
+    if (dto.vit !== undefined) {
+      stats.vit = stats.baseVit = dto.vit;
+      player.currentVit = dto.vit;
+    }
+    return this.persistAndBroadcast(sessionId, state);
+  }
+
+  async setNoCooldown(
+    humanId: string,
+    sessionId: string,
+    dto: NoCooldownDto,
+  ): Promise<CombatState> {
+    const state = await this.session.getStateForParticipant(sessionId, humanId);
+    state.noCooldown = dto.enabled;
+    return this.persistAndBroadcast(sessionId, state);
+  }
+
+  private getDummy(state: CombatState, humanId: string, dummyId: string): CombatPlayer {
+    const dummy = state.players[dummyId];
+    if (!dummy || dummy.playerId === humanId) {
+      throw new BadRequestException('Mannequin introuvable');
+    }
+    return dummy;
   }
 
   private async findOrCreateInventoryItem(humanId: string, itemId: string) {

--- a/apps/web/src/api/playground.api.ts
+++ b/apps/web/src/api/playground.api.ts
@@ -1,0 +1,15 @@
+import type { CombatState, EquipmentSlotType, TerrainType } from '@game/shared-types';
+
+import { apiClient } from './client';
+
+export const playgroundApi = {
+  start: () => apiClient.post<CombatState>('/playground/start'),
+  paint: (sessionId: string, body: { x: number; y: number; terrain: TerrainType }) =>
+    apiClient.post<CombatState>(`/playground/${sessionId}/paint`, body),
+  gather: (sessionId: string, body: { x: number; y: number }) =>
+    apiClient.post<CombatState>(`/playground/${sessionId}/gather`, body),
+  grantEquip: (sessionId: string, body: { itemId: string; slot: EquipmentSlotType }) =>
+    apiClient.post<CombatState>(`/playground/${sessionId}/grant-equip`, body),
+  unequip: (sessionId: string, body: { slot: EquipmentSlotType }) =>
+    apiClient.post<CombatState>(`/playground/${sessionId}/unequip`, body),
+};

--- a/apps/web/src/api/playground.api.ts
+++ b/apps/web/src/api/playground.api.ts
@@ -4,6 +4,7 @@ import { apiClient } from './client';
 
 export const playgroundApi = {
   start: () => apiClient.post<CombatState>('/playground/start'),
+  startCombat: () => apiClient.post<CombatState>('/playground/combat'),
   paint: (sessionId: string, body: { x: number; y: number; terrain: TerrainType }) =>
     apiClient.post<CombatState>(`/playground/${sessionId}/paint`, body),
   gather: (sessionId: string, body: { x: number; y: number }) =>

--- a/apps/web/src/api/playground.api.ts
+++ b/apps/web/src/api/playground.api.ts
@@ -13,4 +13,20 @@ export const playgroundApi = {
     apiClient.post<CombatState>(`/playground/${sessionId}/grant-equip`, body),
   unequip: (sessionId: string, body: { slot: EquipmentSlotType }) =>
     apiClient.post<CombatState>(`/playground/${sessionId}/unequip`, body),
+  addDummy: (sessionId: string, body: { x: number; y: number }) =>
+    apiClient.post<CombatState>(`/playground/${sessionId}/dummy`, body),
+  setDummy: (
+    sessionId: string,
+    body: { dummyId: string; def?: number; res?: number; vit?: number },
+  ) => apiClient.patch<CombatState>(`/playground/${sessionId}/dummy`, body),
+  removeDummy: (sessionId: string, dummyId: string) =>
+    apiClient.delete<CombatState>(`/playground/${sessionId}/dummy/${dummyId}`),
+  resetDummies: (sessionId: string) =>
+    apiClient.post<CombatState>(`/playground/${sessionId}/dummy/reset`),
+  setPlayerStats: (
+    sessionId: string,
+    body: { atk?: number; mag?: number; def?: number; res?: number; vit?: number },
+  ) => apiClient.post<CombatState>(`/playground/${sessionId}/player-stats`, body),
+  setNoCooldown: (sessionId: string, enabled: boolean) =>
+    apiClient.post<CombatState>(`/playground/${sessionId}/no-cooldown`, { enabled }),
 };

--- a/apps/web/src/game/HUD/CombatHUD.spec.tsx
+++ b/apps/web/src/game/HUD/CombatHUD.spec.tsx
@@ -107,6 +107,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('react-router-dom', () => ({
   useNavigate: () => mocks.navigate,
+  useLocation: () => ({ pathname: '/combat/test-session' }),
 }));
 
 vi.mock('../../store/combat.store', () => ({

--- a/apps/web/src/game/HUD/CombatHUD.tsx
+++ b/apps/web/src/game/HUD/CombatHUD.tsx
@@ -130,6 +130,9 @@ export function CombatHUD() {
 
   if (!combatState || !user || !currentPlayer) return null;
 
+  // Bac à sable /playground : pas de système de tour (ni frise, ni fin de tour, ni abandon).
+  const isSandbox = combatState.isPlayground === true;
+
   const handleCombatExit = () => {
     disconnect();
     if (activeSession?.status === "ACTIVE") {
@@ -185,13 +188,15 @@ export function CombatHUD() {
         </div>
       )}
 
-      {/* TOP CENTER: Turn tracker */}
-      <TurnTracker
-        fighters={fighters}
-        currentTurnPlayerId={combatState.currentTurnPlayerId}
-        turnNumber={combatState.turnNumber}
-        selfId={user.id}
-      />
+      {/* TOP CENTER: Turn tracker (masqué en bac à sable : pas de tours) */}
+      {!isSandbox && (
+        <TurnTracker
+          fighters={fighters}
+          currentTurnPlayerId={combatState.currentTurnPlayerId}
+          turnNumber={combatState.turnNumber}
+          selfId={user.id}
+        />
+      )}
 
       {/* BOTTOM PLAYER PANELS */}
       <CombatPlayerPanel playerId={user.id} side="left" showStats={statsOpen} />
@@ -212,20 +217,22 @@ export function CombatHUD() {
               >
                 <img src="/assets/pack/icons/emojis.png" alt="Émotes" style={{ width: '18px', height: '18px' }} />
               </button>
-              <button
-                type="button"
-                className="hud-log-btn"
-                aria-label="Abandonner"
-                title="Abandonner"
-                onClick={() => {
-                  if (window.confirm(t("confirmAbandon") || "Voulez-vous vraiment abandonner le combat ?")) {
-                    surrender();
-                    handleCombatExit();
-                  }
-                }}
-              >
-                <img src="/assets/pack/icons/flag.png" alt="Abandonner" style={{ width: '18px', height: '18px' }} />
-              </button>
+              {!isSandbox && (
+                <button
+                  type="button"
+                  className="hud-log-btn"
+                  aria-label="Abandonner"
+                  title="Abandonner"
+                  onClick={() => {
+                    if (window.confirm(t("confirmAbandon") || "Voulez-vous vraiment abandonner le combat ?")) {
+                      surrender();
+                      handleCombatExit();
+                    }
+                  }}
+                >
+                  <img src="/assets/pack/icons/flag.png" alt="Abandonner" style={{ width: '18px', height: '18px' }} />
+                </button>
+              )}
               <button
                 type="button"
                 className={`hud-log-btn ${tacticsMode ? "active" : ""}`}
@@ -250,12 +257,14 @@ export function CombatHUD() {
                 enemyId ? combatState.players[enemyId]?.stats : undefined
               }
             >
-              <EndTurnButton 
-                isMyTurn={isMyTurn} 
-                onEndTurn={handleEndTurn} 
-                canCastSpell={canCastSpell}
-                hasPm={hasPm}
-              />
+              {!isSandbox && (
+                <EndTurnButton
+                  isMyTurn={isMyTurn}
+                  onEndTurn={handleEndTurn}
+                  canCastSpell={canCastSpell}
+                  hasPm={hasPm}
+                />
+              )}
             </SpellBar>
           </div>
 

--- a/apps/web/src/game/HUD/CombatHUD.tsx
+++ b/apps/web/src/game/HUD/CombatHUD.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import type { CombatPlayer } from "@game/shared-types";
 import { CombatActionType, SpellFamily } from "@game/shared-types";
@@ -107,6 +107,8 @@ export function CombatHUD() {
 
   const user = useAuthStore((s) => s.player);
   const navigate = useNavigate();
+  // Sur /playground, l'écran de fin de combat est géré par la page (retour bac à sable).
+  const isPlaygroundRoute = useLocation().pathname.startsWith("/playground");
   const { activeSession } = useGameSession();
 
   const currentPlayer =
@@ -170,7 +172,7 @@ export function CombatHUD() {
         <div key={uiMessage.id} className={`combat-toast${isToastExiting ? ' exiting' : ''}`}>{uiMessage.text}</div>
       )}
 
-      {showCombatEnd && (
+      {showCombatEnd && !isPlaygroundRoute && (
         <div
           className={`combat-end-overlay ${isWinner ? "victory" : "defeat"}`}
         >

--- a/apps/web/src/game/HUD/CombatPlayerPanel.tsx
+++ b/apps/web/src/game/HUD/CombatPlayerPanel.tsx
@@ -2,25 +2,9 @@ import React, { useCallback, useState } from "react";
 import { useAuthStore } from "../../store/auth.store";
 import { useCombatStore } from "../../store/combat.store";
 import { combatApi } from "../../api/combat.api";
-import { playSfx, type SfxName } from "../../utils/sfx";
 import { CombatActionType } from "@game/shared-types";
 
 import "./CombatPlayerPanel.css";
-
-// Un son de lancement distinct par sort (par code), fallback générique « spellCast ».
-const SPELL_CAST_SFX: Record<string, SfxName> = {
-  "spell-boule-de-feu": "castFireball",
-  "spell-frappe": "castSlash",
-  "spell-claque": "castSlap",
-  "spell-kunai": "castKunai",
-  "spell-bombe-repousse": "castBomb",
-  "spell-soin": "castHeal",
-  "spell-heal": "castHeal",
-  "spell-endurance": "castEndurance",
-  "spell-velocite": "castVelocite",
-  "spell-buff-pm": "castVelocite",
-  "spell-bond": "castLeap",
-};
 
 const getBuffDetails = (type: string, value: number) => {
   const isPositive = value >= 0;
@@ -294,8 +278,8 @@ export function CombatPlayerPanel({ playerId, side, showStats }: CombatPlayerPan
           targetY: targetPos.y,
         });
         if (res?.data) setCombatState(res.data);
-        const castSpell = caster.spells.find((s) => s.id === selectedSpellId);
-        playSfx((castSpell && SPELL_CAST_SFX[castSpell.code]) || "spellCast");
+        // Le son de lancement est joué par le store sur l'évènement SSE SPELL_CAST
+        // (un seul point pour tous les casts : clic case, panneau, ou bot).
         setSelectedSpell(null);
       } catch (err) {
         const message =

--- a/apps/web/src/game/Playground/DamageMeterPanel.tsx
+++ b/apps/web/src/game/Playground/DamageMeterPanel.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useRef, useState } from 'react';
+
+import type { CombatPlayer, SpellDefinition } from '@game/shared-types';
+import { SpellEffectKind } from '@game/shared-types';
+
+import { useCombatStore } from '../../store/combat.store';
+
+import './Playground.css';
+
+interface MeterEntry {
+  id: number;
+  kind: 'damage' | 'heal';
+  spell: string;
+  value: number;
+  min: number;
+  max: number;
+  paCost: number;
+  range: string;
+  target: string;
+}
+
+function findSpell(caster: CombatPlayer | undefined, spellId: string | undefined): SpellDefinition | undefined {
+  if (!caster || !spellId) return undefined;
+  return caster.spells.find((s) => s.id === spellId);
+}
+
+/** Borne effective d'un sort de dégâts : (base + atk|mag) - def|res, clampée à 1. */
+function effectiveRange(spell: SpellDefinition, caster: CombatPlayer, target: CombatPlayer) {
+  const magical = spell.effectKind === SpellEffectKind.DAMAGE_MAGICAL;
+  const power = magical ? caster.stats.mag : caster.stats.atk;
+  const mitig = magical ? target.stats.res : target.stats.def;
+  return {
+    min: Math.max(1, spell.damage.min + power - mitig),
+    max: Math.max(1, spell.damage.max + power - mitig),
+  };
+}
+
+export function DamageMeterPanel() {
+  const combatState = useCombatStore((s) => s.combatState);
+  const lastSpellCast = useCombatStore((s) => s.lastSpellCast);
+  const lastDamageEvent = useCombatStore((s) => s.lastDamageEvent);
+  const lastHealEvent = useCombatStore((s) => s.lastHealEvent);
+  const [log, setLog] = useState<MeterEntry[]>([]);
+  const seq = useRef(0);
+  const lastDmgTs = useRef(0);
+  const lastHealTs = useRef(0);
+
+  useEffect(() => {
+    if (!lastDamageEvent || lastDamageEvent.timestamp === lastDmgTs.current) return;
+    lastDmgTs.current = lastDamageEvent.timestamp;
+    const players = combatState?.players ?? {};
+    const caster = lastSpellCast ? players[lastSpellCast.casterId] : undefined;
+    const target = players[lastDamageEvent.targetId];
+    const spell = findSpell(caster, lastSpellCast?.spellId);
+    const range = spell && caster && target ? effectiveRange(spell, caster, target) : { min: 0, max: 0 };
+    seq.current += 1;
+    const entry: MeterEntry = {
+      id: seq.current,
+      kind: 'damage',
+      spell: spell?.name ?? 'Sort',
+      value: lastDamageEvent.damage,
+      min: range.min,
+      max: range.max,
+      paCost: spell?.paCost ?? 0,
+      range: spell ? `${spell.minRange}-${spell.maxRange}` : '—',
+      target: target?.username ?? 'cible',
+    };
+    setLog((prev) => [entry, ...prev].slice(0, 40));
+  }, [lastDamageEvent, lastSpellCast, combatState]);
+
+  useEffect(() => {
+    if (!lastHealEvent || lastHealEvent.timestamp === lastHealTs.current) return;
+    lastHealTs.current = lastHealEvent.timestamp;
+    const players = combatState?.players ?? {};
+    const caster = lastSpellCast ? players[lastSpellCast.casterId] : undefined;
+    const spell = findSpell(caster, lastSpellCast?.spellId);
+    seq.current += 1;
+    const entry: MeterEntry = {
+      id: seq.current,
+      kind: 'heal',
+      spell: spell?.name ?? 'Soin',
+      value: lastHealEvent.heal,
+      min: spell?.damage.min ?? 0,
+      max: spell?.damage.max ?? 0,
+      paCost: spell?.paCost ?? 0,
+      range: spell ? `${spell.minRange}-${spell.maxRange}` : '—',
+      target: players[lastHealEvent.targetId]?.username ?? 'cible',
+    };
+    setLog((prev) => [entry, ...prev].slice(0, 40));
+  }, [lastHealEvent, lastSpellCast, combatState]);
+
+  return (
+    <div className="pg-panel">
+      <div className="pg-meter-head">
+        <h3 className="pg-title">📊 Damage meter</h3>
+        {log.length > 0 && (
+          <button type="button" className="pg-mini-btn" onClick={() => setLog([])}>
+            Vider
+          </button>
+        )}
+      </div>
+      {log.length === 0 ? (
+        <p className="pg-hint">Lance un sort sur une cible pour mesurer les dégâts.</p>
+      ) : (
+        <div className="pg-meter-list">
+          {log.map((e) => (
+            <div key={e.id} className={`pg-meter-row pg-meter-row--${e.kind}`}>
+              <span className="pg-meter-spell">{e.spell}</span>
+              <span className="pg-meter-val">
+                {e.kind === 'heal' ? '+' : '-'}
+                {e.value}
+              </span>
+              <span className="pg-meter-meta">
+                {e.min}-{e.max} · {e.paCost} PA · ◎{e.range}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/game/Playground/EquipmentPanel.tsx
+++ b/apps/web/src/game/Playground/EquipmentPanel.tsx
@@ -98,7 +98,7 @@ export function EquipmentPanel({ sessionId }: EquipmentPanelProps) {
   };
 
   return (
-    <div className={`pg-panel pg-panel--right${busy ? ' pg-busy' : ''}`}>
+    <div className={`pg-panel${busy ? ' pg-busy' : ''}`}>
       <h3 className="pg-title">🎒 Équipement</h3>
       <p className="pg-hint">Équipe gratuitement n'importe quel objet — stats et sorts en direct. Une arme par main.</p>
 

--- a/apps/web/src/game/Playground/EquipmentPanel.tsx
+++ b/apps/web/src/game/Playground/EquipmentPanel.tsx
@@ -4,19 +4,25 @@ import { useMemo, useState } from 'react';
 import type { CombatState, ItemDefinition } from '@game/shared-types';
 import { EquipmentSlotType, ItemType } from '@game/shared-types';
 
+import { equipmentApi } from '../../api/equipment.api';
 import { itemsApi } from '../../api/items.api';
 import { playgroundApi } from '../../api/playground.api';
-import { useAuthStore } from '../../store/auth.store';
 import { useCombatStore } from '../../store/combat.store';
 
 import './Playground.css';
 
-const SLOT_BY_TYPE: Partial<Record<ItemType, EquipmentSlotType>> = {
-  [ItemType.WEAPON]: EquipmentSlotType.WEAPON_RIGHT,
-  [ItemType.ARMOR_HEAD]: EquipmentSlotType.ARMOR_HEAD,
-  [ItemType.ARMOR_CHEST]: EquipmentSlotType.ARMOR_CHEST,
-  [ItemType.ARMOR_LEGS]: EquipmentSlotType.ARMOR_LEGS,
-  [ItemType.ACCESSORY]: EquipmentSlotType.ACCESSORY,
+// Une arme peut aller dans chaque main ; les autres types n'ont qu'un slot.
+const SLOTS_BY_TYPE: Partial<Record<ItemType, EquipmentSlotType[]>> = {
+  [ItemType.WEAPON]: [EquipmentSlotType.WEAPON_RIGHT, EquipmentSlotType.WEAPON_LEFT],
+  [ItemType.ARMOR_HEAD]: [EquipmentSlotType.ARMOR_HEAD],
+  [ItemType.ARMOR_CHEST]: [EquipmentSlotType.ARMOR_CHEST],
+  [ItemType.ARMOR_LEGS]: [EquipmentSlotType.ARMOR_LEGS],
+  [ItemType.ACCESSORY]: [EquipmentSlotType.ACCESSORY],
+};
+
+const SLOT_HAND_LABEL: Partial<Record<EquipmentSlotType, string>> = {
+  [EquipmentSlotType.WEAPON_RIGHT]: 'Droite',
+  [EquipmentSlotType.WEAPON_LEFT]: 'Gauche',
 };
 
 const GROUP_ORDER: ItemType[] = [
@@ -28,12 +34,14 @@ const GROUP_ORDER: ItemType[] = [
 ];
 
 const GROUP_LABELS: Record<string, string> = {
-  [ItemType.WEAPON]: 'Armes',
+  [ItemType.WEAPON]: 'Armes (une par main)',
   [ItemType.ARMOR_HEAD]: 'Tête',
   [ItemType.ARMOR_CHEST]: 'Torse',
   [ItemType.ARMOR_LEGS]: 'Jambes',
   [ItemType.ACCESSORY]: 'Anneaux',
 };
+
+type EquipmentBySlot = Partial<Record<EquipmentSlotType, { itemId: string } | null>>;
 
 interface EquipmentPanelProps {
   sessionId: string;
@@ -41,9 +49,6 @@ interface EquipmentPanelProps {
 
 export function EquipmentPanel({ sessionId }: EquipmentPanelProps) {
   const setCombatState = useCombatStore((s) => s.setCombatState);
-  const combatState = useCombatStore((s) => s.combatState);
-  const user = useAuthStore((s) => s.player);
-  const userId = user?.id ?? (user as { _id?: string } | null)?._id ?? undefined;
   const [busy, setBusy] = useState(false);
 
   const { data: items = [] } = useQuery({
@@ -51,14 +56,13 @@ export function EquipmentPanel({ sessionId }: EquipmentPanelProps) {
     queryFn: async () => (await itemsApi.getAll()).data as ItemDefinition[],
   });
 
-  const equippedIds = useMemo(() => {
-    const self = userId ? combatState?.players?.[userId] : undefined;
-    const list = (self?.items ?? []) as { id: string }[];
-    return new Set(list.map((it) => it.id));
-  }, [combatState, userId]);
+  const { data: equipment, refetch: refetchEquipment } = useQuery({
+    queryKey: ['playground', 'equipment'],
+    queryFn: async () => (await equipmentApi.getEquipment()).data as EquipmentBySlot,
+  });
 
   const groups = useMemo(() => {
-    const equippable = items.filter((it) => SLOT_BY_TYPE[it.type]);
+    const equippable = items.filter((it) => SLOTS_BY_TYPE[it.type]);
     return GROUP_ORDER.map((type) => ({
       type,
       label: GROUP_LABELS[type],
@@ -66,27 +70,28 @@ export function EquipmentPanel({ sessionId }: EquipmentPanelProps) {
     })).filter((g) => g.items.length > 0);
   }, [items]);
 
-  const applyState = (state: CombatState) => setCombatState(state);
+  const apply = async (state: CombatState) => {
+    setCombatState(state);
+    await refetchEquipment();
+  };
 
-  const handleEquip = async (item: ItemDefinition) => {
-    const slot = SLOT_BY_TYPE[item.type];
-    if (!slot || busy) return;
+  const handleEquip = async (item: ItemDefinition, slot: EquipmentSlotType) => {
+    if (busy) return;
     setBusy(true);
     try {
       const { data } = await playgroundApi.grantEquip(sessionId, { itemId: item.id, slot });
-      applyState(data);
+      await apply(data);
     } finally {
       setBusy(false);
     }
   };
 
-  const handleUnequip = async (item: ItemDefinition) => {
-    const slot = SLOT_BY_TYPE[item.type];
-    if (!slot || busy) return;
+  const handleUnequip = async (slot: EquipmentSlotType) => {
+    if (busy) return;
     setBusy(true);
     try {
       const { data } = await playgroundApi.unequip(sessionId, { slot });
-      applyState(data);
+      await apply(data);
     } finally {
       setBusy(false);
     }
@@ -95,27 +100,37 @@ export function EquipmentPanel({ sessionId }: EquipmentPanelProps) {
   return (
     <div className={`pg-panel pg-panel--right${busy ? ' pg-busy' : ''}`}>
       <h3 className="pg-title">🎒 Équipement</h3>
-      <p className="pg-hint">Équipe gratuitement n'importe quel objet — stats et sorts se mettent à jour en direct.</p>
+      <p className="pg-hint">Équipe gratuitement n'importe quel objet — stats et sorts en direct. Une arme par main.</p>
 
       {groups.map((group) => (
         <div key={group.type} className="pg-equip-group">
           <p className="pg-subtitle">{group.label}</p>
           {group.items.map((item) => {
-            const equipped = equippedIds.has(item.id);
+            const slots = SLOTS_BY_TYPE[item.type] ?? [];
+            const dualWield = slots.length > 1;
             return (
-              <button
-                key={item.id}
-                type="button"
-                className={`pg-item-btn${equipped ? ' is-equipped' : ''}`}
-                onClick={() => (equipped ? handleUnequip(item) : handleEquip(item))}
-              >
-                <span>{item.name}</span>
-                {equipped ? (
-                  <span className="pg-unequip">✕</span>
-                ) : (
-                  <span className="pg-item-rank">rang {item.rank}</span>
-                )}
-              </button>
+              <div key={item.id} className="pg-item-row">
+                <span className="pg-item-name">{item.name}</span>
+                <div className="pg-item-actions">
+                  {slots.map((slot) => {
+                    const equippedHere = equipment?.[slot]?.itemId === item.id;
+                    const hand = SLOT_HAND_LABEL[slot];
+                    let label: string;
+                    if (equippedHere) label = dualWield ? `✕ ${hand}` : '✕';
+                    else label = dualWield ? (hand ?? '') : 'Équiper';
+                    return (
+                      <button
+                        key={slot}
+                        type="button"
+                        className={`pg-slot-btn${equippedHere ? ' is-equipped' : ''}`}
+                        onClick={() => (equippedHere ? handleUnequip(slot) : handleEquip(item, slot))}
+                      >
+                        {label}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
             );
           })}
         </div>

--- a/apps/web/src/game/Playground/EquipmentPanel.tsx
+++ b/apps/web/src/game/Playground/EquipmentPanel.tsx
@@ -1,0 +1,125 @@
+import { useQuery } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
+
+import type { CombatState, ItemDefinition } from '@game/shared-types';
+import { EquipmentSlotType, ItemType } from '@game/shared-types';
+
+import { itemsApi } from '../../api/items.api';
+import { playgroundApi } from '../../api/playground.api';
+import { useAuthStore } from '../../store/auth.store';
+import { useCombatStore } from '../../store/combat.store';
+
+import './Playground.css';
+
+const SLOT_BY_TYPE: Partial<Record<ItemType, EquipmentSlotType>> = {
+  [ItemType.WEAPON]: EquipmentSlotType.WEAPON_RIGHT,
+  [ItemType.ARMOR_HEAD]: EquipmentSlotType.ARMOR_HEAD,
+  [ItemType.ARMOR_CHEST]: EquipmentSlotType.ARMOR_CHEST,
+  [ItemType.ARMOR_LEGS]: EquipmentSlotType.ARMOR_LEGS,
+  [ItemType.ACCESSORY]: EquipmentSlotType.ACCESSORY,
+};
+
+const GROUP_ORDER: ItemType[] = [
+  ItemType.WEAPON,
+  ItemType.ARMOR_HEAD,
+  ItemType.ARMOR_CHEST,
+  ItemType.ARMOR_LEGS,
+  ItemType.ACCESSORY,
+];
+
+const GROUP_LABELS: Record<string, string> = {
+  [ItemType.WEAPON]: 'Armes',
+  [ItemType.ARMOR_HEAD]: 'Tête',
+  [ItemType.ARMOR_CHEST]: 'Torse',
+  [ItemType.ARMOR_LEGS]: 'Jambes',
+  [ItemType.ACCESSORY]: 'Anneaux',
+};
+
+interface EquipmentPanelProps {
+  sessionId: string;
+}
+
+export function EquipmentPanel({ sessionId }: EquipmentPanelProps) {
+  const setCombatState = useCombatStore((s) => s.setCombatState);
+  const combatState = useCombatStore((s) => s.combatState);
+  const user = useAuthStore((s) => s.player);
+  const userId = user?.id ?? (user as { _id?: string } | null)?._id ?? undefined;
+  const [busy, setBusy] = useState(false);
+
+  const { data: items = [] } = useQuery({
+    queryKey: ['playground', 'items'],
+    queryFn: async () => (await itemsApi.getAll()).data as ItemDefinition[],
+  });
+
+  const equippedIds = useMemo(() => {
+    const self = userId ? combatState?.players?.[userId] : undefined;
+    const list = (self?.items ?? []) as { id: string }[];
+    return new Set(list.map((it) => it.id));
+  }, [combatState, userId]);
+
+  const groups = useMemo(() => {
+    const equippable = items.filter((it) => SLOT_BY_TYPE[it.type]);
+    return GROUP_ORDER.map((type) => ({
+      type,
+      label: GROUP_LABELS[type],
+      items: equippable.filter((it) => it.type === type),
+    })).filter((g) => g.items.length > 0);
+  }, [items]);
+
+  const applyState = (state: CombatState) => setCombatState(state);
+
+  const handleEquip = async (item: ItemDefinition) => {
+    const slot = SLOT_BY_TYPE[item.type];
+    if (!slot || busy) return;
+    setBusy(true);
+    try {
+      const { data } = await playgroundApi.grantEquip(sessionId, { itemId: item.id, slot });
+      applyState(data);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleUnequip = async (item: ItemDefinition) => {
+    const slot = SLOT_BY_TYPE[item.type];
+    if (!slot || busy) return;
+    setBusy(true);
+    try {
+      const { data } = await playgroundApi.unequip(sessionId, { slot });
+      applyState(data);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className={`pg-panel pg-panel--right${busy ? ' pg-busy' : ''}`}>
+      <h3 className="pg-title">🎒 Équipement</h3>
+      <p className="pg-hint">Équipe gratuitement n'importe quel objet — stats et sorts se mettent à jour en direct.</p>
+
+      {groups.map((group) => (
+        <div key={group.type} className="pg-equip-group">
+          <p className="pg-subtitle">{group.label}</p>
+          {group.items.map((item) => {
+            const equipped = equippedIds.has(item.id);
+            return (
+              <button
+                key={item.id}
+                type="button"
+                className={`pg-item-btn${equipped ? ' is-equipped' : ''}`}
+                onClick={() => (equipped ? handleUnequip(item) : handleEquip(item))}
+              >
+                <span>{item.name}</span>
+                {equipped ? (
+                  <span className="pg-unequip">✕</span>
+                ) : (
+                  <span className="pg-item-rank">rang {item.rank}</span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/game/Playground/EquipmentPanel.tsx
+++ b/apps/web/src/game/Playground/EquipmentPanel.tsx
@@ -1,15 +1,35 @@
 import { useQuery } from '@tanstack/react-query';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 
-import type { CombatState, ItemDefinition } from '@game/shared-types';
+import type { CombatState, ItemDefinition, PlayerStats } from '@game/shared-types';
 import { EquipmentSlotType, ItemType } from '@game/shared-types';
 
 import { equipmentApi } from '../../api/equipment.api';
 import { itemsApi } from '../../api/items.api';
 import { playgroundApi } from '../../api/playground.api';
+import { useAuthStore } from '../../store/auth.store';
 import { useCombatStore } from '../../store/combat.store';
 
 import './Playground.css';
+
+const ALL_SLOTS = Object.values(EquipmentSlotType);
+const STAT_KEYS: Array<keyof PlayerStats> = ['vit', 'atk', 'mag', 'def', 'res', 'pa', 'pm', 'ini'];
+const PRESETS_KEY = 'pg-build-presets';
+
+type BuildPreset = Partial<Record<EquipmentSlotType, string | null>>;
+
+function loadPresets(): Record<string, BuildPreset> {
+  try {
+    return JSON.parse(localStorage.getItem(PRESETS_KEY) ?? '{}') as Record<string, BuildPreset>;
+  } catch {
+    return {};
+  }
+}
+
+function statDiff(before: PlayerStats | undefined, after: PlayerStats | undefined) {
+  if (!before || !after) return [];
+  return STAT_KEYS.map((k) => ({ key: k, delta: after[k] - before[k] })).filter((d) => d.delta !== 0);
+}
 
 // Une arme peut aller dans chaque main ; les autres types n'ont qu'un slot.
 const SLOTS_BY_TYPE: Partial<Record<ItemType, EquipmentSlotType[]>> = {
@@ -49,7 +69,22 @@ interface EquipmentPanelProps {
 
 export function EquipmentPanel({ sessionId }: EquipmentPanelProps) {
   const setCombatState = useCombatStore((s) => s.setCombatState);
+  const combatState = useCombatStore((s) => s.combatState);
+  const user = useAuthStore((s) => s.player);
+  const userId = user?.id ?? (user as { _id?: string } | null)?._id ?? undefined;
   const [busy, setBusy] = useState(false);
+  const [diff, setDiff] = useState<Array<{ key: string; delta: number }>>([]);
+  const [presets, setPresets] = useState<Record<string, BuildPreset>>(loadPresets);
+  const diffTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const myStats = () => (userId ? combatState?.players?.[userId]?.stats : undefined);
+
+  const showDiff = (before: PlayerStats | undefined, after: PlayerStats | undefined) => {
+    const d = statDiff(before, after);
+    setDiff(d);
+    clearTimeout(diffTimer.current);
+    if (d.length > 0) diffTimer.current = setTimeout(() => setDiff([]), 4000);
+  };
 
   const { data: items = [] } = useQuery({
     queryKey: ['playground', 'items'],
@@ -78,9 +113,11 @@ export function EquipmentPanel({ sessionId }: EquipmentPanelProps) {
   const handleEquip = async (item: ItemDefinition, slot: EquipmentSlotType) => {
     if (busy) return;
     setBusy(true);
+    const before = myStats();
     try {
       const { data } = await playgroundApi.grantEquip(sessionId, { itemId: item.id, slot });
       await apply(data);
+      showDiff(before, userId ? data.players[userId]?.stats : undefined);
     } finally {
       setBusy(false);
     }
@@ -89,9 +126,53 @@ export function EquipmentPanel({ sessionId }: EquipmentPanelProps) {
   const handleUnequip = async (slot: EquipmentSlotType) => {
     if (busy) return;
     setBusy(true);
+    const before = myStats();
     try {
       const { data } = await playgroundApi.unequip(sessionId, { slot });
       await apply(data);
+      showDiff(before, userId ? data.players[userId]?.stats : undefined);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const savePreset = () => {
+    const name = window.prompt('Nom du preset de build ?')?.trim();
+    if (!name) return;
+    const build: BuildPreset = {};
+    for (const slot of ALL_SLOTS) build[slot] = equipment?.[slot]?.itemId ?? null;
+    const next = { ...presets, [name]: build };
+    localStorage.setItem(PRESETS_KEY, JSON.stringify(next));
+    setPresets(next);
+  };
+
+  const deletePreset = (name: string) => {
+    const next = { ...presets };
+    delete next[name];
+    localStorage.setItem(PRESETS_KEY, JSON.stringify(next));
+    setPresets(next);
+  };
+
+  const loadPreset = async (name: string) => {
+    if (busy) return;
+    const build = presets[name];
+    if (!build) return;
+    setBusy(true);
+    const before = myStats();
+    let last: CombatState | undefined;
+    try {
+      for (const slot of ALL_SLOTS) {
+        const target = build[slot] ?? null;
+        const current = equipment?.[slot]?.itemId ?? null;
+        if (target === current) continue;
+        last = target
+          ? (await playgroundApi.grantEquip(sessionId, { itemId: target, slot })).data
+          : (await playgroundApi.unequip(sessionId, { slot })).data;
+      }
+      if (last) {
+        await apply(last);
+        showDiff(before, userId ? last.players[userId]?.stats : undefined);
+      }
     } finally {
       setBusy(false);
     }
@@ -101,6 +182,35 @@ export function EquipmentPanel({ sessionId }: EquipmentPanelProps) {
     <div className={`pg-panel${busy ? ' pg-busy' : ''}`}>
       <h3 className="pg-title">🎒 Équipement</h3>
       <p className="pg-hint">Équipe gratuitement n'importe quel objet — stats et sorts en direct. Une arme par main.</p>
+
+      {diff.length > 0 && (
+        <div className="pg-diff">
+          {diff.map((d) => (
+            <span key={d.key} className={d.delta > 0 ? 'pg-diff-up' : 'pg-diff-down'}>
+              {d.key.toUpperCase()} {d.delta > 0 ? '+' : ''}{d.delta}
+            </span>
+          ))}
+        </div>
+      )}
+
+      <div className="pg-presets">
+        <div className="pg-meter-head">
+          <p className="pg-subtitle" style={{ margin: 0 }}>Builds</p>
+          <button type="button" className="pg-mini-btn" onClick={savePreset}>💾 Sauver</button>
+        </div>
+        {Object.keys(presets).length > 0 && (
+          <div className="pg-preset-list">
+            {Object.keys(presets).map((name) => (
+              <div key={name} className="pg-preset-row">
+                <button type="button" className="pg-preset-load" onClick={() => loadPreset(name)}>
+                  {name}
+                </button>
+                <button type="button" className="pg-unequip" onClick={() => deletePreset(name)}>✕</button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
 
       {groups.map((group) => (
         <div key={group.type} className="pg-equip-group">

--- a/apps/web/src/game/Playground/Playground.css
+++ b/apps/web/src/game/Playground/Playground.css
@@ -440,3 +440,60 @@
   opacity: 0.65;
   font-size: 0.5rem;
 }
+
+/* --- Diff de stats / presets de build --- */
+.pg-diff {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 8px;
+  padding: 4px 6px;
+  background: rgba(0, 0, 0, 0.4);
+  border-radius: 4px;
+  font-size: 0.58rem;
+  font-weight: bold;
+  animation: hud-fade-in 0.2s ease both;
+}
+
+.pg-diff-up {
+  color: var(--heal-green, #22c55e);
+}
+
+.pg-diff-down {
+  color: var(--hp-red, #ef4444);
+}
+
+.pg-presets {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pg-preset-list {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.pg-preset-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.pg-preset-load {
+  flex: 1;
+  padding: 4px 8px;
+  font-family: inherit;
+  font-size: 0.6rem;
+  text-align: left;
+  color: #fff;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 4px;
+}
+
+.pg-preset-load:hover {
+  background: rgb(var(--range-orange-rgb, 252 168 0) / 0.25);
+  border-color: rgba(255, 255, 255, 0.7);
+}

--- a/apps/web/src/game/Playground/Playground.css
+++ b/apps/web/src/game/Playground/Playground.css
@@ -4,16 +4,40 @@
  * `.pg-*` pour éviter la collision avec la classe globale `.glass`.
  */
 
-.pg-panel {
+/* Colonnes de panneaux : flex vertical, scroll, sans masquer le HUD du bas. */
+.pg-stack {
   position: absolute;
+  top: 24px;
+  bottom: 200px;
   z-index: 100;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow-y: auto;
+  pointer-events: none;
+  scrollbar-width: thin;
+}
+
+.pg-stack > * {
   pointer-events: auto;
+}
+
+.pg-stack--left {
+  left: 24px;
+  width: 232px;
+}
+
+.pg-stack--right {
+  right: 24px;
+  width: 264px;
+}
+
+.pg-panel {
+  flex: 0 0 auto;
   display: flex;
   flex-direction: column;
   gap: 8px;
   padding: 12px;
-  max-height: 70vh;
-  overflow-y: auto;
   font-family: var(--font-hud, "BoldPixels", sans-serif);
   color: #fff;
   background: rgba(0, 0, 0, 0.78);
@@ -26,18 +50,6 @@
     inset 0 0 0 1px rgba(0, 0, 0, 0.75),
     inset 0 0 40px rgba(0, 0, 0, 0.65);
   animation: hud-fade-in 0.25s ease both;
-}
-
-.pg-panel--left {
-  left: 24px;
-  top: 24px;
-  width: 220px;
-}
-
-.pg-panel--right {
-  right: 24px;
-  top: 24px;
-  width: 260px;
 }
 
 .pg-title {
@@ -313,4 +325,118 @@
 .pg-end-actions {
   display: flex;
   gap: 12px;
+}
+
+/* --- Contrôles : sliders / cases / cibles / damage meter --- */
+.pg-slider {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.pg-slider-label {
+  font-size: 0.58rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.pg-slider input[type="range"] {
+  width: 100%;
+  height: 4px;
+  cursor: pointer;
+}
+
+.pg-check {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+  font-size: 0.62rem;
+  cursor: pointer;
+}
+
+.pg-mini-btn {
+  padding: 3px 8px;
+  font-family: inherit;
+  font-size: 0.55rem;
+  color: #fff;
+  cursor: pointer;
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 4px;
+}
+
+.pg-mini-btn:hover {
+  background: rgba(255, 255, 255, 0.2);
+  border-color: rgba(255, 255, 255, 0.7);
+}
+
+.pg-target {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 6px;
+}
+
+.pg-target-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  font-size: 0.55rem;
+}
+
+.pg-meter-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.pg-meter-list {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.pg-meter-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-areas: "spell val" "meta meta";
+  gap: 0 6px;
+  padding: 4px 6px;
+  background: rgba(0, 0, 0, 0.35);
+  border-left: 3px solid var(--hp-red, #ef4444);
+  border-radius: 3px;
+  font-size: 0.55rem;
+}
+
+.pg-meter-row--heal {
+  border-left-color: var(--heal-green, #22c55e);
+}
+
+.pg-meter-spell {
+  grid-area: spell;
+  font-weight: bold;
+}
+
+.pg-meter-val {
+  grid-area: val;
+  font-weight: bold;
+  color: var(--hp-red, #ef4444);
+}
+
+.pg-meter-row--heal .pg-meter-val {
+  color: var(--heal-green, #22c55e);
+}
+
+.pg-meter-meta {
+  grid-area: meta;
+  opacity: 0.65;
+  font-size: 0.5rem;
 }

--- a/apps/web/src/game/Playground/Playground.css
+++ b/apps/web/src/game/Playground/Playground.css
@@ -143,48 +143,52 @@
   gap: 4px;
 }
 
-.pg-item-btn {
+.pg-item-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  padding: 6px 8px;
-  font-family: inherit;
-  font-size: 0.6rem;
-  text-align: left;
-  color: #fff;
-  cursor: pointer;
+  padding: 5px 8px;
   background: rgba(0, 0, 0, 0.4);
-  border: 2px solid rgba(255, 255, 255, 0.18);
+  border: 2px solid rgba(255, 255, 255, 0.14);
   outline: 1.5px solid rgba(0, 0, 0, 0.85);
   border-radius: 6px;
-  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.pg-item-btn:hover {
-  border-color: rgba(255, 255, 255, 0.7);
-  transform: translateX(2px);
-}
-
-.pg-item-btn.is-equipped {
-  border-color: rgb(var(--heal-green-rgb, 34 197 94) / 0.9);
-}
-
-.pg-item-rank {
-  font-size: 0.5rem;
-  opacity: 0.7;
-}
-
-.pg-unequip {
-  flex: 0 0 auto;
-  padding: 2px 6px;
+.pg-item-name {
   font-family: inherit;
   font-size: 0.6rem;
   color: #fff;
+}
+
+.pg-item-actions {
+  display: flex;
+  gap: 4px;
+  flex: 0 0 auto;
+}
+
+.pg-slot-btn {
+  min-width: 28px;
+  padding: 3px 8px;
+  font-family: inherit;
+  font-size: 0.55rem;
+  color: #fff;
   cursor: pointer;
-  background: rgb(var(--hp-red-rgb, 239 68 68) / 0.35);
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.28);
   border-radius: 4px;
+  transition: all 0.15s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.pg-slot-btn:hover {
+  border-color: rgba(255, 255, 255, 0.8);
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.pg-slot-btn.is-equipped {
+  color: #fff;
+  background: rgb(var(--heal-green-rgb, 34 197 94) / 0.32);
+  border-color: rgb(var(--heal-green-rgb, 34 197 94) / 0.9);
 }
 
 .pg-busy {

--- a/apps/web/src/game/Playground/Playground.css
+++ b/apps/web/src/game/Playground/Playground.css
@@ -210,6 +210,16 @@
   pointer-events: none;
 }
 
+.pg-arena-row {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+}
+
+.pg-arena-hub {
+  background: rgba(0, 0, 0, 0.55) !important;
+}
+
 .pg-arena-toggle {
   pointer-events: auto;
   padding: 10px 18px;

--- a/apps/web/src/game/Playground/Playground.css
+++ b/apps/web/src/game/Playground/Playground.css
@@ -252,3 +252,55 @@
   opacity: 0.85;
   text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
 }
+
+/* --- Écran de fin de combat (mode combat du playground) --- */
+.pg-end-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: auto;
+  background: rgba(0, 0, 0, 0.82);
+  backdrop-filter: blur(10px);
+  animation: hud-fade-in 0.25s ease both;
+}
+
+.pg-end-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 18px;
+  padding: 28px 36px;
+  background: rgba(0, 0, 0, 0.85);
+  border: 2px solid rgba(255, 255, 255, 0.9);
+  outline: 1.5px solid rgba(0, 0, 0, 0.85);
+  border-radius: 6px;
+  box-shadow: 0 12px 48px rgba(0, 0, 0, 0.7);
+}
+
+.pg-end-overlay.is-victory .pg-end-card {
+  border-color: var(--victory-gold, #fbbf24);
+  box-shadow: 0 0 40px rgb(var(--victory-gold-rgb, 251 191 36) / 0.5);
+}
+
+.pg-end-overlay.is-defeat .pg-end-card {
+  border-color: var(--hp-red, #ef4444);
+  box-shadow: 0 0 40px rgb(var(--hp-red-rgb, 239 68 68) / 0.5);
+}
+
+.pg-end-title {
+  margin: 0;
+  font-family: var(--font-hud, "BoldPixels", sans-serif);
+  font-size: 2.2rem;
+  color: #fff;
+  text-shadow:
+    -2px -2px 0 #000, 2px -2px 0 #000, -2px 2px 0 #000, 2px 2px 0 #000,
+    0 -2px 0 #000, 0 2px 0 #000, -2px 0 0 #000, 2px 0 0 #000;
+}
+
+.pg-end-actions {
+  display: flex;
+  gap: 12px;
+}

--- a/apps/web/src/game/Playground/Playground.css
+++ b/apps/web/src/game/Playground/Playground.css
@@ -191,3 +191,60 @@
   opacity: 0.5;
   pointer-events: none;
 }
+
+/* --- Barre d'arène (bac à sable / combat) --- */
+.pg-arena-bar {
+  position: absolute;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 150;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  pointer-events: none;
+}
+
+.pg-arena-toggle {
+  pointer-events: auto;
+  padding: 10px 18px;
+  font-family: var(--font-hud, "BoldPixels", sans-serif);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #fff;
+  cursor: pointer;
+  background: rgb(var(--range-orange-rgb, 252 168 0) / 0.28);
+  border: 2px solid rgba(255, 255, 255, 0.9);
+  outline: 1.5px solid rgba(0, 0, 0, 0.85);
+  border-radius: 6px;
+  backdrop-filter: blur(12px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.5);
+  transition: all 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+  text-shadow:
+    -2px -2px 0 #000, 2px -2px 0 #000, -2px 2px 0 #000, 2px 2px 0 #000,
+    0 -2px 0 #000, 0 2px 0 #000, -2px 0 0 #000, 2px 0 0 #000;
+}
+
+.pg-arena-toggle:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 28px rgba(0, 0, 0, 0.6);
+}
+
+.pg-arena-toggle:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.pg-arena-toggle.is-combat {
+  background: rgb(var(--hp-red-rgb, 239 68 68) / 0.32);
+}
+
+.pg-arena-label {
+  font-family: var(--font-hud, "BoldPixels", sans-serif);
+  font-size: 0.55rem;
+  color: #fff;
+  opacity: 0.85;
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+}

--- a/apps/web/src/game/Playground/Playground.css
+++ b/apps/web/src/game/Playground/Playground.css
@@ -1,0 +1,193 @@
+/*
+ * Banc de test /playground — surfaces glass conformes à design.md
+ * (double contour pixel, BoldPixels, tokens COMBAT_COLORS). Classes namespacées
+ * `.pg-*` pour éviter la collision avec la classe globale `.glass`.
+ */
+
+.pg-panel {
+  position: absolute;
+  z-index: 100;
+  pointer-events: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  max-height: 70vh;
+  overflow-y: auto;
+  font-family: var(--font-hud, "BoldPixels", sans-serif);
+  color: #fff;
+  background: rgba(0, 0, 0, 0.78);
+  border: 2px solid rgba(255, 255, 255, 0.9);
+  outline: 1.5px solid rgba(0, 0, 0, 0.85);
+  border-radius: 6px;
+  backdrop-filter: blur(12px);
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.6),
+    inset 0 0 0 1px rgba(0, 0, 0, 0.75),
+    inset 0 0 40px rgba(0, 0, 0, 0.65);
+  animation: hud-fade-in 0.25s ease both;
+}
+
+.pg-panel--left {
+  left: 24px;
+  top: 24px;
+  width: 220px;
+}
+
+.pg-panel--right {
+  right: 24px;
+  top: 24px;
+  width: 260px;
+}
+
+.pg-title {
+  margin: 0 0 4px;
+  font-size: 0.8rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  text-shadow:
+    -2px -2px 0 #000, 2px -2px 0 #000, -2px 2px 0 #000, 2px 2px 0 #000,
+    0 -2px 0 #000, 0 2px 0 #000, -2px 0 0 #000, 2px 0 0 #000;
+}
+
+.pg-subtitle {
+  margin: 8px 0 2px;
+  font-size: 0.6rem;
+  opacity: 0.75;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+/* --- Toggle de mode (Play / Paint / Gather) --- */
+.pg-mode-row {
+  display: flex;
+  gap: 6px;
+}
+
+.pg-mode-btn {
+  flex: 1;
+  padding: 6px 4px;
+  font-family: inherit;
+  font-size: 0.62rem;
+  text-transform: uppercase;
+  color: #fff;
+  cursor: pointer;
+  background: rgba(0, 0, 0, 0.4);
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  outline: 1.5px solid rgba(0, 0, 0, 0.85);
+  border-radius: 6px;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.pg-mode-btn:hover {
+  border-color: rgba(255, 255, 255, 0.7);
+  transform: translateY(-2px);
+}
+
+.pg-mode-btn.is-active {
+  border-color: #fff;
+  background: rgb(var(--range-orange-rgb, 252 168 0) / 0.3);
+  box-shadow: 0 0 12px rgb(var(--range-orange-rgb, 252 168 0) / 0.5);
+}
+
+/* --- Palette de terrains --- */
+.pg-terrain-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 6px;
+}
+
+.pg-terrain-btn {
+  position: relative;
+  height: 40px;
+  cursor: pointer;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  outline: 1.5px solid rgba(0, 0, 0, 0.85);
+  border-radius: 6px;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.pg-terrain-btn:hover {
+  transform: translateY(-3px);
+  border-color: rgba(255, 255, 255, 0.8);
+}
+
+.pg-terrain-btn.is-active {
+  border-color: #fff;
+  box-shadow: 0 0 12px rgba(255, 255, 255, 0.6);
+}
+
+.pg-terrain-btn span {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.5rem;
+  font-weight: bold;
+  color: #fff;
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+}
+
+.pg-hint {
+  margin: 4px 0 0;
+  font-size: 0.55rem;
+  line-height: 1.3;
+  opacity: 0.7;
+}
+
+/* --- Panneau équipement --- */
+.pg-equip-group {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pg-item-btn {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 8px;
+  font-family: inherit;
+  font-size: 0.6rem;
+  text-align: left;
+  color: #fff;
+  cursor: pointer;
+  background: rgba(0, 0, 0, 0.4);
+  border: 2px solid rgba(255, 255, 255, 0.18);
+  outline: 1.5px solid rgba(0, 0, 0, 0.85);
+  border-radius: 6px;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.pg-item-btn:hover {
+  border-color: rgba(255, 255, 255, 0.7);
+  transform: translateX(2px);
+}
+
+.pg-item-btn.is-equipped {
+  border-color: rgb(var(--heal-green-rgb, 34 197 94) / 0.9);
+}
+
+.pg-item-rank {
+  font-size: 0.5rem;
+  opacity: 0.7;
+}
+
+.pg-unequip {
+  flex: 0 0 auto;
+  padding: 2px 6px;
+  font-family: inherit;
+  font-size: 0.6rem;
+  color: #fff;
+  cursor: pointer;
+  background: rgb(var(--hp-red-rgb, 239 68 68) / 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 4px;
+}
+
+.pg-busy {
+  opacity: 0.5;
+  pointer-events: none;
+}

--- a/apps/web/src/game/Playground/PlaygroundControlsPanel.tsx
+++ b/apps/web/src/game/Playground/PlaygroundControlsPanel.tsx
@@ -1,0 +1,141 @@
+import { useCallback, useRef } from 'react';
+
+import type { CombatState } from '@game/shared-types';
+
+import { playgroundApi } from '../../api/playground.api';
+import { useAuthStore } from '../../store/auth.store';
+import { useCombatStore } from '../../store/combat.store';
+
+import './Playground.css';
+
+const TARGET_SPOTS: Array<[number, number]> = [
+  [4, 4],
+  [6, 4],
+  [4, 6],
+  [2, 4],
+  [6, 6],
+  [2, 2],
+  [8, 4],
+];
+
+interface SliderProps {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  color: string;
+  onCommit: (v: number) => void;
+}
+
+function Slider({ label, value, min, max, step = 1, color, onCommit }: SliderProps) {
+  return (
+    <label className="pg-slider">
+      <span className="pg-slider-label">
+        {label} <b style={{ color }}>{value}</b>
+      </span>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        style={{ accentColor: color }}
+        onChange={(e) => onCommit(Number(e.target.value))}
+      />
+    </label>
+  );
+}
+
+interface PlaygroundControlsPanelProps {
+  sessionId: string;
+}
+
+export function PlaygroundControlsPanel({ sessionId }: PlaygroundControlsPanelProps) {
+  const combatState = useCombatStore((s) => s.combatState);
+  const setCombatState = useCombatStore((s) => s.setCombatState);
+  const user = useAuthStore((s) => s.player);
+  const userId = user?.id ?? (user as { _id?: string } | null)?._id ?? undefined;
+  const timers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
+
+  const me = userId ? combatState?.players?.[userId] : undefined;
+  const dummies = Object.values(combatState?.players ?? {}).filter((p) => p.playerId !== userId);
+  const noCooldown = combatState?.noCooldown ?? false;
+
+  // Débounce les appels pendant le drag d'un slider.
+  const debounced = useCallback((key: string, fn: () => Promise<{ data: CombatState }>) => {
+    clearTimeout(timers.current[key]);
+    timers.current[key] = setTimeout(() => {
+      void fn().then(({ data }) => setCombatState(data));
+    }, 120);
+  }, [setCombatState]);
+
+  const setStat = (field: 'atk' | 'mag' | 'def' | 'res' | 'vit', v: number) =>
+    debounced(`me-${field}`, () => playgroundApi.setPlayerStats(sessionId, { [field]: v }));
+
+  const setDummyStat = (id: string, field: 'def' | 'res' | 'vit', v: number) =>
+    debounced(`${id}-${field}`, () => playgroundApi.setDummy(sessionId, { dummyId: id, [field]: v }));
+
+  const addTarget = async () => {
+    const [x, y] = TARGET_SPOTS[dummies.length % TARGET_SPOTS.length];
+    const { data } = await playgroundApi.addDummy(sessionId, { x, y });
+    setCombatState(data);
+  };
+
+  const removeTarget = async (id: string) => {
+    const { data } = await playgroundApi.removeDummy(sessionId, id);
+    setCombatState(data);
+  };
+
+  const resetTargets = async () => {
+    const { data } = await playgroundApi.resetDummies(sessionId);
+    setCombatState(data);
+  };
+
+  const toggleNoCd = async () => {
+    const { data } = await playgroundApi.setNoCooldown(sessionId, !noCooldown);
+    setCombatState(data);
+  };
+
+  if (!me) return null;
+
+  return (
+    <div className="pg-panel">
+      <h3 className="pg-title">🎛️ Stats &amp; options</h3>
+
+      <p className="pg-subtitle">Stats joueur (brutes)</p>
+      <Slider label="ATK" value={me.stats.atk} min={0} max={500} color="#fca800" onCommit={(v) => setStat('atk', v)} />
+      <Slider label="MAG" value={me.stats.mag} min={0} max={500} color="#a855f7" onCommit={(v) => setStat('mag', v)} />
+      <Slider label="DEF" value={me.stats.def} min={0} max={500} color="#60a5fa" onCommit={(v) => setStat('def', v)} />
+      <Slider label="RES" value={me.stats.res} min={0} max={500} color="#22c55e" onCommit={(v) => setStat('res', v)} />
+      <Slider label="VIT" value={me.stats.vit} min={1} max={5000} step={10} color="#ef4444" onCommit={(v) => setStat('vit', v)} />
+
+      <label className="pg-check">
+        <input type="checkbox" checked={noCooldown} onChange={toggleNoCd} />
+        Sorts sans cooldown
+      </label>
+
+      <div className="pg-meter-head" style={{ marginTop: '8px' }}>
+        <p className="pg-subtitle" style={{ margin: 0 }}>Cibles ({dummies.length})</p>
+        <div style={{ display: 'flex', gap: '4px' }}>
+          <button type="button" className="pg-mini-btn" onClick={addTarget}>+ Cible</button>
+          {dummies.length > 0 && (
+            <button type="button" className="pg-mini-btn" onClick={resetTargets}>Reset</button>
+          )}
+        </div>
+      </div>
+
+      {dummies.map((d, i) => (
+        <div key={d.playerId} className="pg-target">
+          <div className="pg-target-head">
+            <span>Cible {i + 1} ({d.position.x},{d.position.y}) — {d.currentVit}/{d.stats.vit} PV</span>
+            <button type="button" className="pg-unequip" onClick={() => removeTarget(d.playerId)}>✕</button>
+          </div>
+          <Slider label="PV" value={d.stats.vit} min={1} max={5000} step={10} color="#ef4444" onCommit={(v) => setDummyStat(d.playerId, 'vit', v)} />
+          <Slider label="DEF" value={d.stats.def} min={0} max={500} color="#60a5fa" onCommit={(v) => setDummyStat(d.playerId, 'def', v)} />
+          <Slider label="RES" value={d.stats.res} min={0} max={500} color="#22c55e" onCommit={(v) => setDummyStat(d.playerId, 'res', v)} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/game/Playground/TerrainBrushPanel.tsx
+++ b/apps/web/src/game/Playground/TerrainBrushPanel.tsx
@@ -1,0 +1,86 @@
+import { TERRAIN_LABELS, TerrainType } from '@game/shared-types';
+
+import { TERRAIN_COLORS } from '../ResourceMap/TerrainTile';
+
+import './Playground.css';
+
+export type PlaygroundMode = 'play' | 'paint' | 'gather';
+
+const PAINTABLE_TERRAINS: TerrainType[] = [
+  TerrainType.GROUND,
+  TerrainType.IRON,
+  TerrainType.LEATHER,
+  TerrainType.CRYSTAL,
+  TerrainType.FABRIC,
+  TerrainType.WOOD,
+  TerrainType.HERB,
+  TerrainType.GOLD,
+];
+
+const MODES: { key: PlaygroundMode; label: string }[] = [
+  { key: 'play', label: 'Jouer' },
+  { key: 'paint', label: 'Peindre' },
+  { key: 'gather', label: 'Récolter' },
+];
+
+interface TerrainBrushPanelProps {
+  mode: PlaygroundMode;
+  onModeChange: (mode: PlaygroundMode) => void;
+  selectedTerrain: TerrainType;
+  onTerrainChange: (terrain: TerrainType) => void;
+}
+
+export function TerrainBrushPanel({
+  mode,
+  onModeChange,
+  selectedTerrain,
+  onTerrainChange,
+}: TerrainBrushPanelProps) {
+  return (
+    <div className="pg-panel pg-panel--left">
+      <h3 className="pg-title">🧪 Playground</h3>
+
+      <div className="pg-mode-row">
+        {MODES.map((m) => (
+          <button
+            key={m.key}
+            type="button"
+            className={`pg-mode-btn${mode === m.key ? ' is-active' : ''}`}
+            onClick={() => onModeChange(m.key)}
+          >
+            {m.label}
+          </button>
+        ))}
+      </div>
+
+      {mode === 'paint' && (
+        <>
+          <p className="pg-subtitle">Ressource à poser</p>
+          <div className="pg-terrain-grid">
+            {PAINTABLE_TERRAINS.map((terrain) => (
+              <button
+                key={terrain}
+                type="button"
+                title={TERRAIN_LABELS[terrain]}
+                className={`pg-terrain-btn${selectedTerrain === terrain ? ' is-active' : ''}`}
+                style={{ background: TERRAIN_COLORS[terrain].base }}
+                onClick={() => onTerrainChange(terrain)}
+              >
+                <span>{terrain === TerrainType.GROUND ? 'Sol' : TERRAIN_LABELS[terrain]}</span>
+              </button>
+            ))}
+          </div>
+          <p className="pg-hint">Clique une case pour y poser « {TERRAIN_LABELS[selectedTerrain]} ». « Sol » efface le node.</p>
+        </>
+      )}
+
+      {mode === 'gather' && (
+        <p className="pg-hint">Clique un node de ressource pour le récolter (ajouté à l'inventaire, la case redevient du sol).</p>
+      )}
+
+      {mode === 'play' && (
+        <p className="pg-hint">Mode combat normal : sélectionne un sort puis tape le mannequin. Il ne bouge pas, n'attaque pas et ne meurt jamais.</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/game/Playground/TerrainBrushPanel.tsx
+++ b/apps/web/src/game/Playground/TerrainBrushPanel.tsx
@@ -37,7 +37,7 @@ export function TerrainBrushPanel({
   onTerrainChange,
 }: TerrainBrushPanelProps) {
   return (
-    <div className="pg-panel pg-panel--left">
+    <div className="pg-panel">
       <h3 className="pg-title">🧪 Playground</h3>
 
       <div className="pg-mode-row">

--- a/apps/web/src/game/ResourceMap/TerrainTile.tsx
+++ b/apps/web/src/game/ResourceMap/TerrainTile.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { TerrainType, TERRAIN_PROPERTIES, CombatTerrainType } from '@game/shared-types';
 
-const TERRAIN_COLORS: Record<TerrainType, { base: string; hover: string }> = {
+export const TERRAIN_COLORS: Record<TerrainType, { base: string; hover: string }> = {
   [TerrainType.GROUND]: { base: '#374151', hover: '#4b5563' },
   [TerrainType.IRON]: { base: '#78716c', hover: '#a8a29e' },
   [TerrainType.LEATHER]: { base: '#92400e', hover: '#b45309' },

--- a/apps/web/src/game/UnifiedMap/UnifiedMapScene.tsx
+++ b/apps/web/src/game/UnifiedMap/UnifiedMapScene.tsx
@@ -50,6 +50,9 @@ interface UnifiedMapSceneProps {
   onTileReached?: (node: PathNode) => void;
   onSceneReady?: () => void;
   timeOfDay?: number;
+  /** Banc de test /playground : 'paint'/'gather' détourne le clic de case. */
+  playgroundMode?: 'play' | 'paint' | 'gather';
+  onPlaygroundTileClick?: (x: number, y: number, terrain: TerrainType) => void;
 }
 
 function getProjectileType(spellId: string) {
@@ -76,6 +79,8 @@ export const UnifiedMapScene = React.memo(
     onTileReached,
     onSceneReady,
     timeOfDay = 0,
+    playgroundMode = 'play',
+    onPlaygroundTileClick,
   }: UnifiedMapSceneProps) => {
     const combatState = useCombatStore((state) => state.combatState);
     const selectedSpellId = useCombatStore((state) => state.selectedSpellId);
@@ -774,6 +779,11 @@ export const UnifiedMapScene = React.memo(
 
     const handleTileClickDispatcher = useCallback(
       (x: number, y: number, terrain: TerrainType) => {
+        if (mode === 'combat' && onPlaygroundTileClick && playgroundMode !== 'play') {
+          onPlaygroundTileClick(x, y, terrain);
+          return;
+        }
+
         if (mode === 'combat') {
           void handleCombatTileClick(x, y);
           return;
@@ -781,7 +791,7 @@ export const UnifiedMapScene = React.memo(
 
         onTileClick?.(x, y, terrain);
       },
-      [handleCombatTileClick, mode, onTileClick],
+      [handleCombatTileClick, mode, onTileClick, onPlaygroundTileClick, playgroundMode],
     );
 
     const handlePointerDown = useCallback((e: ThreeEvent<PointerEvent>) => {

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -86,6 +86,11 @@ const QuickCombatPage = lazy(() =>
     default: module.QuickCombatPage,
   })),
 );
+const PlaygroundPage = lazy(() =>
+  import("./pages/PlaygroundPage").then((module) => ({
+    default: module.PlaygroundPage,
+  })),
+);
 
 function PageLoader({ message }: { message?: string }) {
   const { t } = useTranslation();
@@ -222,6 +227,16 @@ root.render(
                         <ProtectedRoute>
                           <LazyPage>
                             <QuickCombatPage />
+                          </LazyPage>
+                        </ProtectedRoute>
+                      }
+                    />
+                    <Route
+                      path="/playground"
+                      element={
+                        <ProtectedRoute>
+                          <LazyPage>
+                            <PlaygroundPage />
                           </LazyPage>
                         </ProtectedRoute>
                       }

--- a/apps/web/src/pages/HubPoiModal.spec.tsx
+++ b/apps/web/src/pages/HubPoiModal.spec.tsx
@@ -48,6 +48,7 @@ function makeProps(overrides?: Partial<HubPoiModalProps>): HubPoiModalProps {
       onJoinRoom: vi.fn(),
       onCancelRoom: vi.fn(),
       onClearError: vi.fn(),
+      onPlayground: vi.fn(),
     },
     ...overrides,
   };

--- a/apps/web/src/pages/HubPoiModal.tsx
+++ b/apps/web/src/pages/HubPoiModal.tsx
@@ -209,7 +209,16 @@ interface RoomsActions extends ActionFeedback {
   onCreateRoom: () => void;
   onJoinRoom: (id: string) => void;
   onCancelRoom: () => void;
+  onPlayground: () => void;
 }
+
+// Banc de test dev : visible uniquement quand le debug est activé (route /playground
+// backend gatée par ENABLE_DEBUG_ROUTES).
+const SHOW_PLAYGROUND = ['1', 'true', 'on', 'yes'].includes(
+  String(import.meta.env.VITE_SHOW_DEBUG ?? '')
+    .toLowerCase()
+    .trim(),
+);
 
 export interface HubPoiModalProps {
   activePoiId: PoiId | null;
@@ -862,7 +871,7 @@ function RoomsHints({ isWaiting, isInQueue, hasOpenSession, busy, color }: { isW
   return null;
 }
 
-function RoomsPanel({ rooms, loading, isWaiting, hasOpenSession, isInQueue, playerId, busy, error, onCreateRoom, onJoinRoom, onCancelRoom, onClearError }: RoomsActions): ReactElement {
+function RoomsPanel({ rooms, loading, isWaiting, hasOpenSession, isInQueue, playerId, busy, error, onCreateRoom, onJoinRoom, onCancelRoom, onClearError, onPlayground }: RoomsActions): ReactElement {
   const createDisabled = isInQueue || (hasOpenSession && !isWaiting) || busy;
   const cta = buildRoomsCta(isWaiting, busy);
   return (
@@ -889,6 +898,19 @@ function RoomsPanel({ rooms, loading, isWaiting, hasOpenSession, isInQueue, play
           onJoinRoom={onJoinRoom}
         />
       </div>
+      {SHOW_PLAYGROUND && (
+        <div style={{ marginTop: '16px', borderTop: '1px solid rgba(255,255,255,0.12)', paddingTop: '12px' }}>
+          <p style={FAINT}>Dev — banc de test sans enjeu.</p>
+          <button
+            type="button"
+            className="hub-modal-cta"
+            style={ctaVars('#a855f7')}
+            onClick={onPlayground}
+          >
+            🧪 Playground (bac à sable)
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/pages/LobbyPage.tsx
+++ b/apps/web/src/pages/LobbyPage.tsx
@@ -324,6 +324,7 @@ export function LobbyPage(): React.ReactNode {
             onJoinRoom: (id) => void handleJoinRoom(id),
             onCancelRoom: () => void handleCancelOpenSession(),
             onClearError: () => action.clearError('rooms'),
+            onPlayground: () => navigate('/playground'),
           }}
         />
       </section>

--- a/apps/web/src/pages/PlaygroundPage.tsx
+++ b/apps/web/src/pages/PlaygroundPage.tsx
@@ -1,0 +1,191 @@
+import { OrthographicCamera, CameraControls, Text } from '@react-three/drei';
+import { Canvas, useLoader } from '@react-three/fiber';
+import CameraControlsImpl from 'camera-controls';
+import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+
+import { TerrainType } from '@game/shared-types';
+
+import { playgroundApi } from '../api/playground.api';
+import { CameraEffects } from '../game/Combat/CameraEffects';
+import { CombatBackgroundShader } from '../game/Combat/CombatBackgroundShader';
+import { CombatHUD } from '../game/HUD/CombatHUD';
+import { EquipmentPanel } from '../game/Playground/EquipmentPanel';
+import { TerrainBrushPanel, type PlaygroundMode } from '../game/Playground/TerrainBrushPanel';
+import { UnifiedMapScene } from '../game/UnifiedMap/UnifiedMapScene';
+import '../game/constants/colors';
+import { useAuthStore } from '../store/auth.store';
+import { useCombatStore } from '../store/combat.store';
+import { getTimeOfDay } from '../utils/timeOfDay';
+
+import './CombatPage.css';
+
+function CombatPreloader() {
+  useLoader(THREE.TextureLoader, [
+    '/assets/sprites/soldier/idle.png',
+    '/assets/sprites/soldier/walk.png',
+    '/assets/sprites/soldier/attack.png',
+    '/assets/sprites/orc/idle.png',
+    '/assets/sprites/orc/walk.png',
+    '/assets/sprites/orc/attack.png',
+  ]);
+  return <Text visible={false}>Preload Font</Text>;
+}
+
+export function PlaygroundPage() {
+  const combatState = useCombatStore((s) => s.combatState);
+  const connectToSession = useCombatStore((s) => s.connectToSession);
+  const disconnect = useCombatStore((s) => s.disconnect);
+  const setCombatState = useCombatStore((s) => s.setCombatState);
+  const authInitialize = useAuthStore((s) => s.initialize);
+
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [mode, setMode] = useState<PlaygroundMode>('play');
+  const [selectedTerrain, setSelectedTerrain] = useState<TerrainType>(TerrainType.WOOD);
+  const controlsRef = useRef<CameraControlsImpl>(null);
+  // Démarrage idempotent : StrictMode invoque l'effet deux fois, mais on ne doit
+  // créer qu'une seule session (sinon collision sur l'index unique combat public).
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    const boot = async () => {
+      if (startedRef.current) return;
+      startedRef.current = true;
+      try {
+        await authInitialize();
+        const { data } = await playgroundApi.start();
+        setSessionId(data.sessionId);
+        connectToSession(data.sessionId);
+      } catch (error) {
+        console.error('Playground boot failed', error);
+      }
+    };
+    void boot();
+    return () => {
+      disconnect();
+    };
+  }, [authInitialize, connectToSession, disconnect]);
+
+  const handlePlaygroundTileClick = useCallback(
+    async (x: number, y: number) => {
+      if (!sessionId) return;
+      try {
+        if (mode === 'paint') {
+          const { data } = await playgroundApi.paint(sessionId, { x, y, terrain: selectedTerrain });
+          setCombatState(data);
+        } else if (mode === 'gather') {
+          const { data } = await playgroundApi.gather(sessionId, { x, y });
+          setCombatState(data);
+        }
+      } catch (error) {
+        console.error('Playground tile action failed', error);
+      }
+    },
+    [mode, selectedTerrain, sessionId, setCombatState],
+  );
+
+  const gameMap = useMemo(() => {
+    if (!combatState?.map?.tiles) return null;
+    const grid = Array(combatState.map.height)
+      .fill(0)
+      .map(() => Array(combatState.map.width).fill(TerrainType.GROUND));
+    for (const t of combatState.map.tiles) {
+      if (grid[t.y] && grid[t.y][t.x] !== undefined) grid[t.y][t.x] = t.type;
+    }
+    return {
+      width: combatState.map.width,
+      height: combatState.map.height,
+      grid,
+      seedId: 'FORGE' as const,
+    };
+  }, [combatState?.map]);
+
+  const timeOfDay = getTimeOfDay(1);
+
+  return (
+    <div className="combat-page-container">
+      {!combatState && (
+        <div className="combat-overlay">
+          <div className="loading-spinner"></div>
+          <p>Préparation du playground…</p>
+        </div>
+      )}
+
+      <div className="combat-layout">
+        <div className="combat-game-zone">
+          <Canvas
+            shadows={{ type: THREE.PCFShadowMap }}
+            gl={{ antialias: true, alpha: false, powerPreference: 'high-performance' }}
+            dpr={[1, 2]}
+            camera={{ fov: 30 }}
+          >
+            <CombatBackgroundShader timeOfDay={timeOfDay} />
+            <OrthographicCamera makeDefault position={[20, 20, 20]} zoom={50} near={0.1} far={1000} />
+            <CameraControls
+              ref={controlsRef}
+              minZoom={15}
+              maxZoom={120}
+              minPolarAngle={0}
+              maxPolarAngle={Math.PI / 2.1}
+              mouseButtons={{
+                left: CameraControlsImpl.ACTION.ROTATE,
+                right: CameraControlsImpl.ACTION.NONE,
+                middle: CameraControlsImpl.ACTION.NONE,
+                wheel: CameraControlsImpl.ACTION.ZOOM,
+              }}
+              touches={{
+                one: CameraControlsImpl.ACTION.TOUCH_ROTATE,
+                two: CameraControlsImpl.ACTION.TOUCH_ZOOM,
+                three: CameraControlsImpl.ACTION.NONE,
+              }}
+            />
+            <CameraEffects controlsRef={controlsRef} />
+            <ambientLight intensity={1.5} />
+            <directionalLight
+              position={[5, 10, 5]}
+              intensity={2}
+              castShadow
+              shadow-mapSize={[1024, 1024]}
+              shadow-bias={-0.0004}
+              shadow-normalBias={0.04}
+              shadow-camera-far={50}
+              shadow-camera-left={-10}
+              shadow-camera-right={10}
+              shadow-camera-top={10}
+              shadow-camera-bottom={-10}
+            />
+            <Suspense fallback={null}>
+              <CombatPreloader />
+            </Suspense>
+            {gameMap && sessionId && (
+              <Suspense fallback={null}>
+                <UnifiedMapScene
+                  mode="combat"
+                  map={gameMap}
+                  sessionId={sessionId}
+                  timeOfDay={timeOfDay}
+                  playgroundMode={mode}
+                  onPlaygroundTileClick={handlePlaygroundTileClick}
+                />
+              </Suspense>
+            )}
+          </Canvas>
+
+          <CombatHUD />
+
+          {sessionId && (
+            <>
+              <TerrainBrushPanel
+                mode={mode}
+                onModeChange={setMode}
+                selectedTerrain={selectedTerrain}
+                onTerrainChange={setSelectedTerrain}
+              />
+              <EquipmentPanel sessionId={sessionId} />
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/pages/PlaygroundPage.tsx
+++ b/apps/web/src/pages/PlaygroundPage.tsx
@@ -11,7 +11,9 @@ import { playgroundApi } from '../api/playground.api';
 import { CameraEffects } from '../game/Combat/CameraEffects';
 import { CombatBackgroundShader } from '../game/Combat/CombatBackgroundShader';
 import { CombatHUD } from '../game/HUD/CombatHUD';
+import { DamageMeterPanel } from '../game/Playground/DamageMeterPanel';
 import { EquipmentPanel } from '../game/Playground/EquipmentPanel';
+import { PlaygroundControlsPanel } from '../game/Playground/PlaygroundControlsPanel';
 import { TerrainBrushPanel, type PlaygroundMode } from '../game/Playground/TerrainBrushPanel';
 import { UnifiedMapScene } from '../game/UnifiedMap/UnifiedMapScene';
 import '../game/constants/colors';
@@ -235,13 +237,19 @@ export function PlaygroundPage() {
 
           {sessionId && isSandbox && (
             <>
-              <TerrainBrushPanel
-                mode={mode}
-                onModeChange={setMode}
-                selectedTerrain={selectedTerrain}
-                onTerrainChange={setSelectedTerrain}
-              />
-              <EquipmentPanel sessionId={sessionId} />
+              <div className="pg-stack pg-stack--left">
+                <TerrainBrushPanel
+                  mode={mode}
+                  onModeChange={setMode}
+                  selectedTerrain={selectedTerrain}
+                  onTerrainChange={setSelectedTerrain}
+                />
+                <PlaygroundControlsPanel sessionId={sessionId} />
+              </div>
+              <div className="pg-stack pg-stack--right">
+                <EquipmentPanel sessionId={sessionId} />
+                <DamageMeterPanel />
+              </div>
             </>
           )}
 

--- a/apps/web/src/pages/PlaygroundPage.tsx
+++ b/apps/web/src/pages/PlaygroundPage.tsx
@@ -2,6 +2,7 @@ import { OrthographicCamera, CameraControls, Text } from '@react-three/drei';
 import { Canvas, useLoader } from '@react-three/fiber';
 import CameraControlsImpl from 'camera-controls';
 import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import * as THREE from 'three';
 
 import { TerrainType } from '@game/shared-types';
@@ -47,7 +48,13 @@ export function PlaygroundPage() {
   const [selectedTerrain, setSelectedTerrain] = useState<TerrainType>(TerrainType.WOOD);
   const [switching, setSwitching] = useState(false);
   const controlsRef = useRef<CameraControlsImpl>(null);
+  const navigate = useNavigate();
   const isSandbox = arena === 'sandbox';
+
+  const handleBackToHub = useCallback(() => {
+    disconnect();
+    navigate('/');
+  }, [disconnect, navigate]);
   // Démarrage idempotent : StrictMode invoque l'effet deux fois, mais on ne doit
   // créer qu'une seule session (sinon collision sur l'index unique combat public).
   const startedRef = useRef(false);
@@ -204,14 +211,23 @@ export function PlaygroundPage() {
           <CombatHUD />
 
           <div className="pg-arena-bar">
-            <button
-              type="button"
-              className={`pg-arena-toggle${isSandbox ? '' : ' is-combat'}`}
-              disabled={switching}
-              onClick={() => switchArena(isSandbox ? 'combat' : 'sandbox')}
-            >
-              {isSandbox ? '⚔️ Lancer un vrai combat' : '🧪 Retour au bac à sable'}
-            </button>
+            <div className="pg-arena-row">
+              <button
+                type="button"
+                className="pg-arena-toggle pg-arena-hub"
+                onClick={handleBackToHub}
+              >
+                🏠 Hub
+              </button>
+              <button
+                type="button"
+                className={`pg-arena-toggle${isSandbox ? '' : ' is-combat'}`}
+                disabled={switching}
+                onClick={() => switchArena(isSandbox ? 'combat' : 'sandbox')}
+              >
+                {isSandbox ? '⚔️ Lancer un vrai combat' : '🧪 Retour au bac à sable'}
+              </button>
+            </div>
             <span className="pg-arena-label">
               {isSandbox ? 'Bac à sable — sans tours, PA/PM illimités' : 'Combat tour par tour vs IA'}
             </span>

--- a/apps/web/src/pages/PlaygroundPage.tsx
+++ b/apps/web/src/pages/PlaygroundPage.tsx
@@ -34,10 +34,12 @@ function CombatPreloader() {
 
 export function PlaygroundPage() {
   const combatState = useCombatStore((s) => s.combatState);
+  const winnerId = useCombatStore((s) => s.winnerId);
   const connectToSession = useCombatStore((s) => s.connectToSession);
   const disconnect = useCombatStore((s) => s.disconnect);
   const setCombatState = useCombatStore((s) => s.setCombatState);
   const authInitialize = useAuthStore((s) => s.initialize);
+  const user = useAuthStore((s) => s.player);
 
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [arena, setArena] = useState<'sandbox' | 'combat'>('sandbox');
@@ -49,6 +51,9 @@ export function PlaygroundPage() {
   // Démarrage idempotent : StrictMode invoque l'effet deux fois, mais on ne doit
   // créer qu'une seule session (sinon collision sur l'index unique combat public).
   const startedRef = useRef(false);
+  const userId = user?.id ?? (user as { _id?: string } | null)?._id ?? undefined;
+  const combatEnded = arena === 'combat' && !!winnerId && !switching;
+  const isWinner = !!userId && winnerId === userId;
 
   useEffect(() => {
     const boot = async () => {
@@ -222,6 +227,32 @@ export function PlaygroundPage() {
               />
               <EquipmentPanel sessionId={sessionId} />
             </>
+          )}
+
+          {combatEnded && (
+            <div className={`pg-end-overlay ${isWinner ? 'is-victory' : 'is-defeat'}`}>
+              <div className="pg-end-card">
+                <h2 className="pg-end-title">{isWinner ? '🏆 Victoire' : '💀 Défaite'}</h2>
+                <div className="pg-end-actions">
+                  <button
+                    type="button"
+                    className="pg-arena-toggle"
+                    disabled={switching}
+                    onClick={() => switchArena('combat')}
+                  >
+                    ⚔️ Rejouer
+                  </button>
+                  <button
+                    type="button"
+                    className="pg-arena-toggle is-combat"
+                    disabled={switching}
+                    onClick={() => switchArena('sandbox')}
+                  >
+                    🧪 Retour au bac à sable
+                  </button>
+                </div>
+              </div>
+            </div>
           )}
         </div>
       </div>

--- a/apps/web/src/pages/PlaygroundPage.tsx
+++ b/apps/web/src/pages/PlaygroundPage.tsx
@@ -40,9 +40,12 @@ export function PlaygroundPage() {
   const authInitialize = useAuthStore((s) => s.initialize);
 
   const [sessionId, setSessionId] = useState<string | null>(null);
+  const [arena, setArena] = useState<'sandbox' | 'combat'>('sandbox');
   const [mode, setMode] = useState<PlaygroundMode>('play');
   const [selectedTerrain, setSelectedTerrain] = useState<TerrainType>(TerrainType.WOOD);
+  const [switching, setSwitching] = useState(false);
   const controlsRef = useRef<CameraControlsImpl>(null);
+  const isSandbox = arena === 'sandbox';
   // Démarrage idempotent : StrictMode invoque l'effet deux fois, mais on ne doit
   // créer qu'une seule session (sinon collision sur l'index unique combat public).
   const startedRef = useRef(false);
@@ -66,9 +69,31 @@ export function PlaygroundPage() {
     };
   }, [authInitialize, connectToSession, disconnect]);
 
+  const switchArena = useCallback(
+    async (target: 'sandbox' | 'combat') => {
+      setSwitching(true);
+      try {
+        disconnect();
+        const { data } =
+          target === 'combat'
+            ? await playgroundApi.startCombat()
+            : await playgroundApi.start();
+        setArena(target);
+        setMode('play');
+        setSessionId(data.sessionId);
+        connectToSession(data.sessionId);
+      } catch (error) {
+        console.error('Playground arena switch failed', error);
+      } finally {
+        setSwitching(false);
+      }
+    },
+    [connectToSession, disconnect],
+  );
+
   const handlePlaygroundTileClick = useCallback(
     async (x: number, y: number) => {
-      if (!sessionId) return;
+      if (!sessionId || arena !== 'sandbox') return;
       try {
         if (mode === 'paint') {
           const { data } = await playgroundApi.paint(sessionId, { x, y, terrain: selectedTerrain });
@@ -164,7 +189,7 @@ export function PlaygroundPage() {
                   map={gameMap}
                   sessionId={sessionId}
                   timeOfDay={timeOfDay}
-                  playgroundMode={mode}
+                  playgroundMode={isSandbox ? mode : 'play'}
                   onPlaygroundTileClick={handlePlaygroundTileClick}
                 />
               </Suspense>
@@ -173,7 +198,21 @@ export function PlaygroundPage() {
 
           <CombatHUD />
 
-          {sessionId && (
+          <div className="pg-arena-bar">
+            <button
+              type="button"
+              className={`pg-arena-toggle${isSandbox ? '' : ' is-combat'}`}
+              disabled={switching}
+              onClick={() => switchArena(isSandbox ? 'combat' : 'sandbox')}
+            >
+              {isSandbox ? '⚔️ Lancer un vrai combat' : '🧪 Retour au bac à sable'}
+            </button>
+            <span className="pg-arena-label">
+              {isSandbox ? 'Bac à sable — sans tours, PA/PM illimités' : 'Combat tour par tour vs IA'}
+            </span>
+          </div>
+
+          {sessionId && isSandbox && (
             <>
               <TerrainBrushPanel
                 mode={mode}

--- a/apps/web/src/store/combat.store.ts
+++ b/apps/web/src/store/combat.store.ts
@@ -5,7 +5,7 @@ import { CombatActionType } from '@game/shared-types';
 
 
 import { combatApi } from '../api/combat.api';
-import { playSfx } from '../utils/sfx';
+import { playSfx, SPELL_CAST_SFX } from '../utils/sfx';
 
 import { useAuthStore } from './auth.store';
 
@@ -260,6 +260,8 @@ export const useCombatStore = create<CombatStore>((set, get) => ({
           'SPELL_CAST',
           withConnectionGuard<Omit<SpellCastEvent, 'timestamp'>>((data) => {
             set({ lastSpellCast: { ...data, timestamp: Date.now() } });
+            // Son de lancement distinct par sort, pour TOUT cast (clic case ou panneau).
+            playSfx(SPELL_CAST_SFX[data.spellId] ?? 'spellCast');
           }),
         );
 

--- a/apps/web/src/utils/sfx.ts
+++ b/apps/web/src/utils/sfx.ts
@@ -106,6 +106,9 @@ const SFX = {
     '11111mqnbhVWL9Zv6NBPBWMDjhC6J1YqAUe8MtPJ4AwNeBr87RxcR7Qi7xqKq4Q8nifZ9V1qbwrJGH1LDEvGDoYo8rFF6h9KzMQjiCWLj3cm8aQGqw2s14s',
   castLeap:
     '11111Fc13ScxjeU5T2qZVimPPgv4qtk1g1fcX6xyoGEqm2wgtEMPujo6c4DKD9onX5BAeeRmKQX1JtFBMaBTu4MMr4uZqp4bvqfe8bneqTZffQty1yindTnP',
+  // invocation du Menhir : impact de pierre lourd et sourd
+  castMenhir:
+    '7BMHBGAc8o7kxuwyGTS8GpMzXZeA6TcnVXk6YN9bhytMQrm4PE7EsfATY7rhPaNqtnfzAx5inX2Rygam9b9hi6PBb2yEY4EoqV115ivo7WgSWmDnqN23YXS9D',
   // dégâts infligés
   damageDealt:
     '34T6PkjPGwq3wpvt66AnJsmdzYpb5joLRYgpu9YhSi2UNqTAKSKGG1YTTf3jcs8Bv6vr8r8X9Q2RTTRhnDe6JgZz7wncNfrnGKgtcqgZ4DFtSW21QhDSq8q3M',
@@ -169,6 +172,22 @@ const SFX = {
 } satisfies Record<string, string>;
 
 export type SfxName = keyof typeof SFX;
+
+/** Son de lancement distinct par sort (clé = code du sort). Fallback : « spellCast ». */
+export const SPELL_CAST_SFX: Record<string, SfxName> = {
+  "spell-boule-de-feu": "castFireball",
+  "spell-frappe": "castSlash",
+  "spell-claque": "castSlap",
+  "spell-kunai": "castKunai",
+  "spell-bombe-repousse": "castBomb",
+  "spell-soin": "castHeal",
+  "spell-heal": "castHeal",
+  "spell-endurance": "castEndurance",
+  "spell-velocite": "castVelocite",
+  "spell-buff-pm": "castVelocite",
+  "spell-bond": "castLeap",
+  "spell-menhir": "castMenhir",
+};
 
 // Un son est synthétisé une seule fois puis rejoué (chaque play() crée une nouvelle source).
 const cache = new Map<SfxName, SfxrAudio>();

--- a/libs/shared-types/src/combat.types.ts
+++ b/libs/shared-types/src/combat.types.ts
@@ -84,6 +84,7 @@ export interface CombatPlayer {
   skin?: string;
   items?: any[];
   casterId?: string;
+  spawn?: CombatPosition; // Playground : position d'origine pour le reset des mannequins
 }
 
 export enum CombatActionType {
@@ -113,4 +114,5 @@ export interface CombatState {
   };
   winnerId?: string; // Ajout du gagnant
   isPlayground?: boolean; // Mode banc de test (/playground) : panneaux dev, pas de fin de combat
+  noCooldown?: boolean; // Playground : ignore les cooldowns de sorts
 }

--- a/libs/shared-types/src/combat.types.ts
+++ b/libs/shared-types/src/combat.types.ts
@@ -112,4 +112,5 @@ export interface CombatState {
     tiles: Tile[];
   };
   winnerId?: string; // Ajout du gagnant
+  isPlayground?: boolean; // Mode banc de test (/playground) : panneaux dev, pas de fin de combat
 }


### PR DESCRIPTION
## 🎯 Pourquoi

Besoin d'un **banc de test** pour itérer vite sur le gameplay : essayer tous les sorts, tout l'équipement et les ressources sans monter une partie complète, et **équilibrer** (dégâts, résistances, builds) de façon mesurable. Outil **dev-only**, gaté par le flag existant `SHOW_DEBUG` (back) / `VITE_SHOW_DEBUG` (front) — jamais chargé en prod.

## 🔧 Quoi

- **Page `/playground`** : réutilise la scène de combat + le HUD ; accessible depuis l'onglet *Rooms personnalisées* (gaté debug) ou en direct.
- **Bac à sable** (sans tours, PA/PM illimités, no-cooldown) avec **mannequin immobile à PV illimités**, **pinceau de ressources** récoltables, **équip instantané gratuit** (bi-arme, stats/sorts en direct).
- **Banc d'équilibrage** : **damage meter** (dégât réel + fourchette effective + PA + portée), **cibles paramétrables** (DEF/RES/PV) en multi, **sliders de stats joueur**, **presets de build**, **diff de stats** à l'équip.
- **Bascule mode combat** : lance un vrai tour-par-tour vs IA (PV finis, IA mobile) ; écran de fin → retour bac à sable.
- **Module orchestrateur dev-only** `apps/api/src/playground/` (gaté `SHOW_DEBUG`) + fix son de cast distinct par sort (joué sur SSE `SPELL_CAST`) + son du Menhir.

> ⚠️ Diff > 400 lignes : feature complète et cohérente, **100 % dev-only** (aucun code chargé en prod), majoritairement de nouveaux fichiers isolés (`playground/`, `game/Playground/`).

## ✅ Checklist

### Tests
- [x] Logique neuve couverte (`MapService.generateFlatMap`, `PlaygroundService` paint/gather/equip).
- [x] `nx affected -t test` passe (api 423 · web 356 · shared-types 25 · game-engine 75) — relancé par le hook pre-commit à chaque commit.
- [x] Vérif E2E manuelle (API + navigateur) de chaque feature.

### Qualité
- [x] Pas d'`any` dans le code neuf ; pas de `console.log` orphelin (Logger Nest côté API).
- [x] DTO `class-validator` sur toutes les entrées HTTP playground.
- [ ] `yarn lint` — le repo est déjà rouge (dette existante connue) ; le code neuf épouse le style alentour.
- [x] Pas de duplication front/back (types → `shared-types`, calculs → `game-engine`).

### Architecture
- [x] Couplage Combat↔Economy : le playground est un **composition-root dev-only** (ni combat ni economy), il n'introduit pas d'import direct combat→economy en code de prod.
- [x] UI conforme à `design.md` (glass, BoldPixels, tokens `COMBAT_COLORS`).
- [x] Cible `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
