### PR TITLE
feat(wind): star-clump grass, terrain texture, leaf wind, 3D wind gusts

### DIFF
--- a/apps/web/src/game/UnifiedMap/InstancedFoliage.tsx
+++ b/apps/web/src/game/UnifiedMap/InstancedFoliage.tsx
@@ -1,33 +1,31 @@
-import { useFBX, useTexture } from "@react-three/drei";
-import { useFrame } from "@react-three/fiber";
-import React, { useRef, useLayoutEffect, useMemo } from "react";
-import * as THREE from "three";
-import { mergeGeometries } from "three/examples/jsm/utils/BufferGeometryUtils.js";
+import { useFBX, useTexture } from '@react-three/drei';
+import { useFrame } from '@react-three/fiber';
+import React, { useRef, useLayoutEffect, useMemo } from 'react';
+import * as THREE from 'three';
+import { mergeGeometries } from 'three/examples/jsm/utils/BufferGeometryUtils.js';
 
-import type { GameMap } from "@game/shared-types";
-import {
-  TerrainType,
-  TERRAIN_PROPERTIES,
-  CombatTerrainType,
-} from "@game/shared-types";
+import type { GameMap } from '@game/shared-types';
+import { TerrainType, TERRAIN_PROPERTIES, CombatTerrainType } from '@game/shared-types';
 
-import { assetUrl } from "../constants/assetUrl";
+import { assetUrl } from '../constants/assetUrl';
 
-const BUSH_URLS = ["/assets/models/Bush_4E.fbx", "/assets/models/Bush_4F.fbx"].map(assetUrl);
-const TREE_URLS = ["/assets/models/Tree_02.fbx", "/assets/models/Tree_04.fbx"].map(assetUrl);
+import { seededRandom } from './noise';
+
+const BUSH_URLS = ['/assets/models/Bush_4E.fbx', '/assets/models/Bush_4F.fbx'].map(assetUrl);
+const TREE_URLS = ['/assets/models/Tree_02.fbx', '/assets/models/Tree_04.fbx'].map(assetUrl);
 const ROCK_FBX_URLS = [
-  "/assets/models/Rock_2E.fbx",
-  "/assets/models/Rock_2F.fbx",
-  "/assets/models/Rock_2G.fbx",
-  "/assets/models/Rock_2H.fbx",
+  '/assets/models/Rock_2E.fbx',
+  '/assets/models/Rock_2F.fbx',
+  '/assets/models/Rock_2G.fbx',
+  '/assets/models/Rock_2H.fbx',
 ].map(assetUrl);
 const GRASS_URLS = [
-  "/assets/models/Grass_1A.fbx",
-  "/assets/models/Grass_1B.fbx",
-  "/assets/models/Grass_2A.fbx",
-  "/assets/models/Grass_2B.fbx",
+  '/assets/models/Grass_1A.fbx',
+  '/assets/models/Grass_1B.fbx',
+  '/assets/models/Grass_2A.fbx',
+  '/assets/models/Grass_2B.fbx',
 ].map(assetUrl);
-const TEXTURE_PATH = assetUrl("/assets/models/forest_texture.png");
+const TEXTURE_PATH = assetUrl('/assets/models/forest_texture.png');
 
 // Slots = one InstancedMesh per (category, variant). Fixed order: bush, tree, rock, grass.
 const BUSH_SLOT = 0;
@@ -38,28 +36,37 @@ const GRASS_SLOT = ROCK_SLOT + ROCK_VARIANTS;
 const GRASS_VARIANTS = GRASS_URLS.length;
 const SLOT_COUNT = GRASS_SLOT + GRASS_VARIANTS;
 
-// Grass cluster optimization: we merge CLUSTER_SIZE tufts into a single geometry.
-// Instead of rendering 300-600 individual instances per tile, we render a smaller set of clusters.
-// This yields dense grass with extremely low vertex and draw-call count, plus zero shadow map overhead.
-const CLUSTER_SIZE = 40;
-const GRASS_SPREAD = 1.1; // Spread of tufts within a cluster (from center)
-const GRASS_MIN_TUFTS = 6; // Min clusters per tile (6 * 40 = 240 tufts)
-const GRASS_MAX_TUFTS = 6; // Max clusters per tile (6 * 40 = 240 tufts)
-const GRASS_JITTER = 0.2; // Jitter of the cluster centers on the tile
+// Grass grows only in the joints between tiles (like a stone terrace), in seeded
+// star-shaped clumps placed on tile-corner junctions. Blades overflow onto tiles.
+// All placement derives from a per-map seed (hashMap) so it is random each new combat
+// map but identical on page reload of the same combat.
+const GRASS_CLUMPS_MIN = 2;          // min sparkle clumps on the whole terrain
+const GRASS_CLUMPS_MAX = 6;          // max sparkle clumps
+const GRASS_CLUMP_DENSITY_MIN = 500; // min candidate blades per clump
+const GRASS_CLUMP_DENSITY_MAX = 2000;// max candidate blades per clump
+const GRASS_CLUMP_RADIUS = 0.52;     // max arm reach — straddles the gap and spills onto tiles
+const GRASS_STAR_POINTS = 4;         // number of sparkle arms
+const GRASS_STAR_SHARPNESS = 8.0;    // higher = thinner, pointier arms
+const GRASS_STAR_MIN_RADIUS = 0.05;  // between-arm radius fraction (0 = no blades between arms)
+const GRASS_ARM_LENGTH_MIN = 0.8;    // shortest arm fraction — wide gap to MAX = very uneven star
+const GRASS_ARM_LENGTH_MAX = 6.0;    // longest arm fraction
+const GRASS_CORE_RADIUS_MIN = 0.01;  // min dense central disc radius (world units)
+const GRASS_CORE_RADIUS_MAX = 0.1;  // max dense central disc radius
+const GRASS_DENSITY_FALLOFF = 0.5;   // higher = sparser toward the arm tips
+const GRASS_CLUMP_SALT = 42;         // shifts all clump placement (combine with per-map seed)
 
 // FBX sources are in cm; bushes/trees keep their hand-tuned multipliers.
 const TREE_SCALE = 0.015 * 0.35;
 // Bushes/rocks/grass are normalised by footprint so new variants share a coherent size.
 const BUSH_TARGET = 0.8;
 const ROCK_TARGET = 0.84; // 0.84 = 1.05 - 20%
-const GRASS_TARGET = 0.06;
+const GRASS_TARGET = 0.05;
 
-function seededRandom(seed: number): number {
-  const x = Math.sin(seed + 1) * 43758.5453123;
-  return x - Math.floor(x);
-}
+const GRASS_OPACITY = 0.9;
+const BUSH_OPACITY = 0.7;
+const LEAF_OPACITY = 0.99;
 
-interface FoliageData {
+export interface FoliageData {
   x: number;
   y: number;
   slot: number;
@@ -68,24 +75,92 @@ interface FoliageData {
   oz: number;
 }
 
-function pushGrass(
-  list: FoliageData[],
-  x: number,
-  y: number,
-  seed: number,
-): void {
-  const tufts =
-    GRASS_MIN_TUFTS + Math.floor(seededRandom(seed * 17) * GRASS_MAX_TUFTS);
-  for (let i = 0; i < tufts; i++) {
-    const gs = seed * 100 + i;
-    list.push({
-      x,
-      y,
-      slot: GRASS_SLOT + Math.floor(seededRandom(gs * 19) * GRASS_VARIANTS),
-      seed: gs,
-      ox: (seededRandom(gs * 23) - 0.5) * GRASS_JITTER,
-      oz: (seededRandom(gs * 29) - 0.5) * GRASS_JITTER,
-    });
+export function isTileWalkable(map: GameMap, tx: number, ty: number): boolean {
+  if (tx < 0 || ty < 0 || tx >= map.width || ty >= map.height) return false;
+  const terrain = map.grid[ty][tx] as TerrainType;
+  return TERRAIN_PROPERTIES[terrain]?.combatType !== CombatTerrainType.HOLE;
+}
+
+// Deterministic FNV-1a hash of the map (dims + every terrain cell). Same combat map →
+// same value on reload; a freshly generated map → a different value → different grass.
+export function hashMap(map: GameMap): number {
+  let h = 2166136261 >>> 0;
+  const mix = (v: number): void => {
+    h = Math.imul(h ^ v, 16777619) >>> 0;
+  };
+  mix(map.width);
+  mix(map.height);
+  for (let y = 0; y < map.height; y++) {
+    const row = map.grid[y];
+    for (let x = 0; x < map.width; x++) {
+      const t = String(row[x]);
+      for (let k = 0; k < t.length; k++) mix(t.charCodeAt(k));
+    }
+  }
+  return (h % 1_000_000) + 1;
+}
+
+// Place grass clumps on tile-corner junctions (the point where 4 tiles meet).
+// Each corner is at world (ix - W/2, iz - H/2) for integer ix,iz — exactly in the gap.
+// Blades are scattered radially from that point and spill onto adjacent tiles.
+export function buildGrass(list: FoliageData[], map: GameMap): void {
+  const baseSeed = hashMap(map) + GRASS_CLUMP_SALT;
+  const clumpCount = GRASS_CLUMPS_MIN + Math.floor(seededRandom(baseSeed) * (GRASS_CLUMPS_MAX - GRASS_CLUMPS_MIN + 1));
+
+  for (let c = 0; c < clumpCount; c++) {
+    const ix = 1 + Math.floor(seededRandom(baseSeed * 3.1 + c * 7.7) * (map.width - 1));
+    const iz = 1 + Math.floor(seededRandom(baseSeed * 5.3 + c * 11.3) * (map.height - 1));
+
+    // Skip corner if all 4 adjacent tiles are unwalkable
+    const anyWalkable = isTileWalkable(map, ix - 1, iz - 1) || isTileWalkable(map, ix, iz - 1)
+      || isTileWalkable(map, ix - 1, iz) || isTileWalkable(map, ix, iz);
+    if (!anyWalkable) continue;
+
+    const cwx = ix - map.width / 2;
+    const cwz = iz - map.height / 2;
+    const density = GRASS_CLUMP_DENSITY_MIN + Math.floor(seededRandom(baseSeed + c * 19) * (GRASS_CLUMP_DENSITY_MAX - GRASS_CLUMP_DENSITY_MIN));
+
+    // Per-clump: each arm gets its own length multiplier (wide range → uneven sparkle).
+    const armLengths: number[] = [];
+    for (let a = 0; a < GRASS_STAR_POINTS; a++) {
+      armLengths.push(GRASS_ARM_LENGTH_MIN + seededRandom(baseSeed + c * 37 + a * 13) * (GRASS_ARM_LENGTH_MAX - GRASS_ARM_LENGTH_MIN));
+    }
+    // Dense core disc, radius varies per clump (fills the very center regardless of star shape).
+    const coreRadius = GRASS_CORE_RADIUS_MIN + seededRandom(baseSeed + c * 53) * (GRASS_CORE_RADIUS_MAX - GRASS_CORE_RADIUS_MIN);
+
+    for (let b = 0; b < density; b++) {
+      const bseed = baseSeed + c * 1000 + b;
+      const r = seededRandom(bseed * 2.1) * GRASS_CLUMP_RADIUS;
+      const theta = seededRandom(bseed * 3.7) * Math.PI * 2;
+
+      // Star shape: rMax = arm length * starFactor (peaks at arm angles, shrinks between).
+      const armIdx = Math.floor((theta / (Math.PI * 2)) * GRASS_STAR_POINTS) % GRASS_STAR_POINTS;
+      const starFactor = Math.pow(Math.max(0, Math.cos(GRASS_STAR_POINTS * theta)), GRASS_STAR_SHARPNESS);
+      const rMax = GRASS_CLUMP_RADIUS * armLengths[armIdx] * (GRASS_STAR_MIN_RADIUS + starFactor * (1 - GRASS_STAR_MIN_RADIUS));
+
+      const inCore = r < coreRadius;
+      if (!inCore && r > rMax) continue;
+
+      // Density falloff outside core: dense at center, sparse toward tips.
+      if (!inCore) {
+        const normalized = r / Math.max(rMax, 0.001);
+        if (seededRandom(bseed * 5.9) > Math.pow(1 - normalized, GRASS_DENSITY_FALLOFF)) continue;
+      }
+
+      const bwx = cwx + r * Math.cos(theta);
+      const bwz = cwz + r * Math.sin(theta);
+      const tx = Math.floor(bwx + map.width / 2);
+      const tz = Math.floor(bwz + map.height / 2);
+      if (!isTileWalkable(map, tx, tz)) continue;
+      list.push({
+        x: tx,
+        y: tz,
+        slot: GRASS_SLOT + Math.floor(seededRandom(bseed * 13) * GRASS_VARIANTS),
+        seed: bseed,
+        ox: bwx - (tx - map.width / 2 + 0.5),
+        oz: bwz - (tz - map.height / 2 + 0.5),
+      });
+    }
   }
 }
 
@@ -113,13 +188,8 @@ function extractMergedGeometry(group: THREE.Group): MergedGeometry | null {
   cloned.traverse((child) => {
     const mesh = child as THREE.Mesh;
     if (!mesh.isMesh) return;
-    const name = (mesh.name || "").toLowerCase();
-    if (
-      name.includes("collider") ||
-      name.includes("helper") ||
-      name.includes("dummy")
-    )
-      return;
+    const name = (mesh.name || '').toLowerCase();
+    if (name.includes('collider') || name.includes('helper') || name.includes('dummy')) return;
     const geo = mesh.geometry.clone();
     geo.applyMatrix4(mesh.matrixWorld);
     subGeos.push(geo);
@@ -127,10 +197,7 @@ function extractMergedGeometry(group: THREE.Group): MergedGeometry | null {
 
   if (subGeos.length === 0) return null;
 
-  const merged =
-    subGeos.length === 1
-      ? subGeos[0]
-      : (mergeGeometries(subGeos, false) ?? subGeos[0]);
+  const merged = subGeos.length === 1 ? subGeos[0] : (mergeGeometries(subGeos, false) ?? subGeos[0]);
   merged.computeBoundingBox();
   const box = merged.boundingBox!;
   const center = new THREE.Vector3();
@@ -141,109 +208,126 @@ function extractMergedGeometry(group: THREE.Group): MergedGeometry | null {
   return { geometry: merged, size };
 }
 
-function buildFbxAsset(
-  group: THREE.Group,
-  texture: THREE.Texture,
-  scale: number,
-  target?: number,
-  isGrass?: boolean,
-): Asset | null {
-  const merged = extractMergedGeometry(group);
-  if (!merged) return null;
-  // Use MeshLambertMaterial for grass to maximize performance, MeshStandardMaterial for others
-  const material = isGrass
-    ? new THREE.MeshLambertMaterial({ map: texture })
-    : new THREE.MeshStandardMaterial({
-        map: texture,
-        roughness: 1.0,
-        metalness: 0.0,
-      });
-  return {
-    geometry: merged.geometry,
-    material,
-    scale: target ? fitScale(merged.size, target) : scale,
+type GreenSampler = (u: number, v: number) => number;
+
+// Read the shared texture once into a canvas, expose per-UV "greenness" (how much the
+// pixel leans green vs red/blue). Used to tell tree leaves from trunk/branches.
+function buildGreenSampler(texture: THREE.Texture): GreenSampler | null {
+  const img = texture.image as HTMLImageElement | ImageBitmap | undefined;
+  const w = img?.width ?? 0;
+  const h = img?.height ?? 0;
+  if (!img || !w || !h) return null;
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d', { willReadFrequently: true });
+  if (!ctx) return null;
+  ctx.drawImage(img, 0, 0);
+  const data = ctx.getImageData(0, 0, w, h).data;
+  return (u, v) => {
+    const px = Math.min(w - 1, Math.max(0, Math.floor(u * w)));
+    const py = Math.min(h - 1, Math.max(0, Math.floor((1 - v) * h)));
+    const idx = (py * w + px) * 4;
+    const r = data[idx] / 255;
+    const g = data[idx + 1] / 255;
+    const b = data[idx + 2] / 255;
+    return Math.max(0, g - Math.max(r, b));
   };
 }
 
-function buildGrassClusterAsset(
-  baseAsset: Asset | null,
-  clusterSize: number,
-  jitterRange: number,
-  seedOffset: number,
-): Asset | null {
-  if (!baseAsset) return null;
-
-  const subGeos: THREE.BufferGeometry[] = [];
-  const matrix = new THREE.Matrix4();
-  const position = new THREE.Vector3();
-  const rotation = new THREE.Quaternion();
-  const scaleVec = new THREE.Vector3();
-  const euler = new THREE.Euler();
-
-  const baseGeo = baseAsset.geometry;
-  const baseScale = baseAsset.scale;
-
-  for (let i = 0; i < clusterSize; i++) {
-    const geo = baseGeo.clone();
-    const seed = seedOffset + i;
-
-    // Position relative within the cluster tile
-    position.set(
-      (seededRandom(seed * 23) - 0.5) * jitterRange,
-      0,
-      (seededRandom(seed * 29) - 0.5) * jitterRange,
-    );
-
-    // Rotation Y
-    euler.set(0, seededRandom(seed * 7) * Math.PI * 2, 0);
-    rotation.setFromEuler(euler);
-
-    // Scale variation around baseScale
-    const s = baseScale * (0.8 + seededRandom(seed * 31) * 0.4);
-    scaleVec.set(s, s, s);
-
-    matrix.compose(position, rotation, scaleVec);
-    geo.applyMatrix4(matrix);
-    subGeos.push(geo);
+// Bake a 0..1 "is this vertex a leaf" mask into the geometry from its UVs, so the wind
+// shader can move only the green-textured parts without sampling textures on the GPU.
+function addLeafMask(geo: THREE.BufferGeometry, sample: GreenSampler): boolean {
+  const uv = geo.getAttribute('uv');
+  if (!uv) return false;
+  const mask = new Float32Array(uv.count);
+  for (let i = 0; i < uv.count; i++) {
+    mask[i] = Math.min(1, sample(uv.getX(i), uv.getY(i)) * 6);
   }
+  geo.setAttribute('aLeaf', new THREE.BufferAttribute(mask, 1));
+  return true;
+}
 
-  if (subGeos.length === 0) return null;
+interface FbxAssetOptions {
+  scale?: number;
+  target?: number;
+  opacity?: number;
+  wind?: 'grass' | 'leaf';
+  greenSampler?: GreenSampler | null;
+}
 
-  const merged = mergeGeometries(subGeos, false);
+function buildFbxAsset(group: THREE.Group, texture: THREE.Texture, opts: FbxAssetOptions): Asset | null {
+  const merged = extractMergedGeometry(group);
   if (!merged) return null;
-
-  return {
-    geometry: merged,
-    material: baseAsset.material,
-    scale: 1.0,
-  };
+  const opacity = opts.opacity ?? 1;
+  // roughness 1 / metalness 0 keeps the matte look (no plastic highlights) under scene lighting.
+  const material = new THREE.MeshStandardMaterial({
+    map: texture,
+    roughness: 1.0,
+    metalness: 0.0,
+    transparent: opacity < 1,
+    opacity,
+  });
+  if (opts.wind === 'grass') applyGrassWind(material);
+  if (opts.wind === 'leaf' && opts.greenSampler && addLeafMask(merged.geometry, opts.greenSampler)) {
+    applyLeafWind(material);
+  }
+  const scale = opts.target ? fitScale(merged.size, opts.target) : (opts.scale ?? 1);
+  return { geometry: merged.geometry, material, scale };
 }
 
 // Vertex-only wind: bends each blade by its local height, phased by world position.
 // Pure GPU math + one shared uTime uniform → no extra geometry, no textures, ~free.
-const WIND_VERTEX_CHUNK = `#include <begin_vertex>
+const GRASS_WIND_CHUNK = `#include <begin_vertex>
   vec4 windWorld = modelMatrix * instanceMatrix * vec4(transformed, 1.0);
   float windPhase = uTime * 1.6 + windWorld.x * 0.55 + windWorld.z * 0.55;
   float windBend = max(transformed.y, 0.0) * 0.25;
   transformed.x += sin(windPhase) * windBend;
   transformed.z += cos(windPhase * 0.8) * windBend * 0.6;`;
 
-function applyWind(material: THREE.Material): void {
-  material.onBeforeCompile = (shader: THREE.Shader): void => {
+function applyGrassWind(material: THREE.Material): void {
+  material.onBeforeCompile = (shader): void => {
     shader.uniforms.uTime = { value: 0 };
-    shader.vertexShader =
-      `uniform float uTime;\n${shader.vertexShader}`.replace(
-        "#include <begin_vertex>",
-        WIND_VERTEX_CHUNK,
-      );
+    shader.vertexShader = `uniform float uTime;\n${shader.vertexShader}`.replace(
+      '#include <begin_vertex>',
+      GRASS_WIND_CHUNK,
+    );
     material.userData.shader = shader;
   };
   material.needsUpdate = true;
 }
 
-export const InstancedFoliage = React.memo(({ map, mode }: { map: GameMap; mode?: 'combat' | 'farming' }) => {
-  // Mettre à true pour réactiver l'herbe
-  const effectiveShowGrass = false;
+// Leaf wind: amplitude scales with the baked green mask and local height, so only the
+// upper green canopy moves while the trunk (mask ~0) stays rigid.
+// Realism comes from layering three signals:
+//   - gust: slow envelope travelling across the world → waves of stronger/weaker wind
+//   - sway: directional base oscillation
+//   - flutter: faster, smaller secondary wobble on the leaf tips
+// A small downward dip (-y) sells a real bend instead of a flat slide.
+const LEAF_WIND_FACTOR = 0.005;
+const LEAF_WIND_CHUNK = `#include <begin_vertex>
+  vec4 leafWorld = modelMatrix * instanceMatrix * vec4(transformed, 1.0);
+  float leafPhase = uTime * 1.2 + leafWorld.x * 0.4 + leafWorld.z * 0.4;
+  float gust = 5.55 + 0.85 * sin(uTime * 0.45 + leafWorld.x * 0.15 + leafWorld.z * 0.1);
+  float sway = sin(leafPhase) + 0.05 * sin(leafPhase * 2.3 + 1.7);
+  float leafBend = aLeaf * max(transformed.y, 0.0) * ${LEAF_WIND_FACTOR} * (0.5 + gust);
+  transformed.x += sway * leafBend;
+  transformed.z += cos(leafPhase * 0.85) * leafBend * 0.6;
+  transformed.y -= abs(sway) * leafBend * 0.9;`;
+
+function applyLeafWind(material: THREE.Material): void {
+  material.onBeforeCompile = (shader): void => {
+    shader.uniforms.uTime = { value: 0 };
+    shader.vertexShader = `uniform float uTime;\nattribute float aLeaf;\n${shader.vertexShader}`.replace(
+      '#include <begin_vertex>',
+      LEAF_WIND_CHUNK,
+    );
+    material.userData.shader = shader;
+  };
+  material.needsUpdate = true;
+}
+
+export const InstancedFoliage = React.memo(({ map }: { map: GameMap }) => {
   const texture = useTexture(TEXTURE_PATH);
   texture.colorSpace = THREE.SRGBColorSpace;
 
@@ -262,69 +346,26 @@ export const InstancedFoliage = React.memo(({ map, mode }: { map: GameMap; mode?
 
   const slots = useMemo<(Asset | null)[]>(() => {
     const out = new Array<Asset | null>(SLOT_COUNT).fill(null);
-    out[BUSH_SLOT] = buildFbxAsset(bush0, texture, 0, BUSH_TARGET);
-    out[BUSH_SLOT + 1] = buildFbxAsset(bush1, texture, 0, BUSH_TARGET);
-    out[TREE_SLOT] = buildFbxAsset(tree0, texture, TREE_SCALE);
-    out[TREE_SLOT + 1] = buildFbxAsset(tree1, texture, TREE_SCALE);
-    out[ROCK_SLOT] = buildFbxAsset(rock0, texture, 0, ROCK_TARGET);
-    out[ROCK_SLOT + 1] = buildFbxAsset(rock1, texture, 0, ROCK_TARGET);
-    out[ROCK_SLOT + 2] = buildFbxAsset(rock2, texture, 0, ROCK_TARGET);
-    out[ROCK_SLOT + 3] = buildFbxAsset(rock3, texture, 0, ROCK_TARGET);
-    const rawGrass0 = buildFbxAsset(grass0, texture, 0, GRASS_TARGET, true);
-    const rawGrass1 = buildFbxAsset(grass1, texture, 0, GRASS_TARGET, true);
-    const rawGrass2 = buildFbxAsset(grass2, texture, 0, GRASS_TARGET, true);
-    const rawGrass3 = buildFbxAsset(grass3, texture, 0, GRASS_TARGET, true);
-
-    out[GRASS_SLOT] = buildGrassClusterAsset(
-      rawGrass0,
-      CLUSTER_SIZE,
-      GRASS_SPREAD,
-      1000,
-    );
-    out[GRASS_SLOT + 1] = buildGrassClusterAsset(
-      rawGrass1,
-      CLUSTER_SIZE,
-      GRASS_SPREAD,
-      2000,
-    );
-    out[GRASS_SLOT + 2] = buildGrassClusterAsset(
-      rawGrass2,
-      CLUSTER_SIZE,
-      GRASS_SPREAD,
-      3000,
-    );
-    out[GRASS_SLOT + 3] = buildGrassClusterAsset(
-      rawGrass3,
-      CLUSTER_SIZE,
-      GRASS_SPREAD,
-      4000,
-    );
-    for (let i = GRASS_SLOT; i < SLOT_COUNT; i++) {
-      const grass = out[i];
-      if (grass) applyWind(grass.material);
-    }
+    const green = buildGreenSampler(texture);
+    out[BUSH_SLOT] = buildFbxAsset(bush0, texture, { target: BUSH_TARGET, opacity: BUSH_OPACITY });
+    out[BUSH_SLOT + 1] = buildFbxAsset(bush1, texture, { target: BUSH_TARGET, opacity: BUSH_OPACITY });
+    out[TREE_SLOT] = buildFbxAsset(tree0, texture, { scale: TREE_SCALE, opacity: LEAF_OPACITY, wind: 'leaf', greenSampler: green });
+    out[TREE_SLOT + 1] = buildFbxAsset(tree1, texture, { scale: TREE_SCALE, opacity: LEAF_OPACITY, wind: 'leaf', greenSampler: green });
+    out[ROCK_SLOT] = buildFbxAsset(rock0, texture, { target: ROCK_TARGET });
+    out[ROCK_SLOT + 1] = buildFbxAsset(rock1, texture, { target: ROCK_TARGET });
+    out[ROCK_SLOT + 2] = buildFbxAsset(rock2, texture, { target: ROCK_TARGET });
+    out[ROCK_SLOT + 3] = buildFbxAsset(rock3, texture, { target: ROCK_TARGET });
+    const grassOpts = { target: GRASS_TARGET, opacity: GRASS_OPACITY, wind: 'grass' as const };
+    out[GRASS_SLOT] = buildFbxAsset(grass0, texture, grassOpts);
+    out[GRASS_SLOT + 1] = buildFbxAsset(grass1, texture, grassOpts);
+    out[GRASS_SLOT + 2] = buildFbxAsset(grass2, texture, grassOpts);
+    out[GRASS_SLOT + 3] = buildFbxAsset(grass3, texture, grassOpts);
     return out;
-  }, [
-    bush0,
-    bush1,
-    tree0,
-    tree1,
-    rock0,
-    rock1,
-    rock2,
-    rock3,
-    grass0,
-    grass1,
-    grass2,
-    grass3,
-    texture,
-  ]);
+  }, [bush0, bush1, tree0, tree1, rock0, rock1, rock2, rock3, grass0, grass1, grass2, grass3, texture]);
 
   useFrame((state) => {
-    for (let i = GRASS_SLOT; i < SLOT_COUNT; i++) {
-      const shader = slots[i]?.material.userData.shader as
-        | { uniforms: { uTime: { value: number } } }
-        | undefined;
+    for (const asset of slots) {
+      const shader = asset?.material.userData.shader as { uniforms: { uTime: { value: number } } } | undefined;
       if (shader) shader.uniforms.uTime.value = state.clock.elapsedTime;
     }
   });
@@ -338,36 +379,15 @@ export const InstancedFoliage = React.memo(({ map, mode }: { map: GameMap; mode?
         const seed = x * 1000 + y;
 
         if (terrain === TerrainType.WOOD) {
-          list.push({
-            x,
-            y,
-            slot: TREE_SLOT + Math.floor(seededRandom(seed) * TREE_URLS.length),
-            seed,
-            ox: 0,
-            oz: 0,
-          });
+          list.push({ x, y, slot: TREE_SLOT + Math.floor(seededRandom(seed) * TREE_URLS.length), seed, ox: 0, oz: 0 });
         } else if (terrain === TerrainType.HERB) {
-          list.push({
-            x,
-            y,
-            slot: BUSH_SLOT + Math.floor(seededRandom(seed) * BUSH_URLS.length),
-            seed,
-            ox: 0,
-            oz: 0,
-          });
-        } else if (props.combatType === CombatTerrainType.WALL && terrain !== TerrainType.WALL) {
-          list.push({
-            x,
-            y,
-            slot: ROCK_SLOT + Math.floor(seededRandom(seed) * ROCK_VARIANTS),
-            seed,
-            ox: 0,
-            oz: 0,
-          });
+          list.push({ x, y, slot: BUSH_SLOT + Math.floor(seededRandom(seed) * BUSH_URLS.length), seed, ox: 0, oz: 0 });
+        } else if (props.combatType === CombatTerrainType.WALL) {
+          list.push({ x, y, slot: ROCK_SLOT + Math.floor(seededRandom(seed) * ROCK_VARIANTS), seed, ox: 0, oz: 0 });
         }
-        pushGrass(list, x, y, seed);
       }
     }
+    buildGrass(list, map);
     return list;
   }, [map]);
 
@@ -393,11 +413,7 @@ export const InstancedFoliage = React.memo(({ map, mode }: { map: GameMap; mode?
       if (!mesh || !asset) continue;
 
       const s = asset.scale;
-      position.set(
-        item.x - map.width / 2 + 0.5 + item.ox,
-        0,
-        item.y - map.height / 2 + 0.5 + item.oz,
-      );
+      position.set(item.x - map.width / 2 + 0.5 + item.ox, 0, item.y - map.height / 2 + 0.5 + item.oz);
       euler.set(0, seededRandom(item.seed * 7) * Math.PI * 2, 0);
       rotation.setFromEuler(euler);
       scaleVec.set(s, s, s);
@@ -412,26 +428,21 @@ export const InstancedFoliage = React.memo(({ map, mode }: { map: GameMap; mode?
 
   return (
     <group>
-      {slots.map((asset, slot) => {
-        const isGrass = slot >= GRASS_SLOT;
-        if (isGrass && !effectiveShowGrass) return null;
-        return asset && counts[slot] > 0 ? (
+      {slots.map((asset, slot) =>
+        asset && counts[slot] > 0 ? (
           <instancedMesh
             key={slot}
-            ref={(el) => {
-              meshRefs.current[slot] = el;
-            }}
+            ref={(el) => { meshRefs.current[slot] = el; }}
             args={[asset.geometry, asset.material, counts[slot]]}
-            castShadow={!isGrass}
+            castShadow
             receiveShadow
             raycast={() => null}
           />
-        ) : null;
-      })}
+        ) : null,
+      )}
     </group>
   );
 });
 
-for (const url of [...BUSH_URLS, ...TREE_URLS, ...ROCK_FBX_URLS, ...GRASS_URLS])
-  useFBX.preload(url);
+for (const url of [...BUSH_URLS, ...TREE_URLS, ...ROCK_FBX_URLS, ...GRASS_URLS]) useFBX.preload(url);
 useTexture.preload(TEXTURE_PATH);

--- a/apps/web/src/game/UnifiedMap/InstancedTerrain.tsx
+++ b/apps/web/src/game/UnifiedMap/InstancedTerrain.tsx
@@ -1,13 +1,64 @@
 import { extend } from '@react-three/fiber';
-import React, { useRef, useLayoutEffect } from 'react';
+import React, { useRef, useLayoutEffect, useMemo } from 'react';
 import * as THREE from 'three';
 import { RoundedBoxGeometry } from 'three-stdlib';
 
 import type { GameMap} from '@game/shared-types';
 import { TerrainType, TERRAIN_PROPERTIES, CombatTerrainType } from '@game/shared-types';
 
+import { fbm } from './noise';
+
 
 extend({ RoundedBoxGeometry });
+
+// World-space repeat of the procedural grain: lower = larger, softer terrain features.
+const TERRAIN_TEX_SCALE = 0.15;
+
+// Subtle FBM grayscale grain so tile tops read as terrain, not flat painted squares.
+// Multiplied onto the per-instance colour, so the checker/terrain tint is preserved.
+function makeTerrainTexture(): THREE.Texture {
+  const size = 256;
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return new THREE.Texture();
+  const img = ctx.createImageData(size, size);
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      // Two scales: broad mottling (dirt patches) + fine grain (soil texture).
+      const broad = fbm(x * 0.04, y * 0.04, 7);
+      const grain = fbm(x * 0.2, y * 0.2, 23);
+      const n = broad * 0.6 + grain * 0.4;
+      const v = Math.floor((0.55 + n * 0.45) * 255);
+      const i = (y * size + x) * 4;
+      img.data[i] = v;
+      img.data[i + 1] = v;
+      img.data[i + 2] = v;
+      img.data[i + 3] = 255;
+    }
+  }
+  ctx.putImageData(img, 0, 0);
+  const tex = new THREE.CanvasTexture(canvas);
+  tex.wrapS = THREE.RepeatWrapping;
+  tex.wrapT = THREE.RepeatWrapping;
+  return tex;
+}
+
+// Drive the grain UVs from world position so the texture flows across tiles continuously
+// instead of repeating identically per cell (which would re-expose the grid).
+function makeTerrainTopMaterial(): THREE.MeshStandardMaterial {
+  const mat = new THREE.MeshStandardMaterial({ map: makeTerrainTexture(), roughness: 1, metalness: 0 });
+  mat.onBeforeCompile = (shader): void => {
+    shader.vertexShader = shader.vertexShader.replace(
+      '#include <uv_vertex>',
+      `#include <uv_vertex>
+      vec4 terrainWorld = modelMatrix * instanceMatrix * vec4( position, 1.0 );
+      vMapUv = terrainWorld.xz * ${TERRAIN_TEX_SCALE.toFixed(3)};`,
+    );
+  };
+  return mat;
+}
 
 interface RoundedBoxGeometryProps {
   args?: [width?: number, height?: number, depth?: number];
@@ -39,7 +90,7 @@ const TERRAIN_COLORS: Record<TerrainType, string> = {
   [TerrainType.WOOD]: '#166534',
   [TerrainType.HERB]: '#4ade80',
   [TerrainType.GOLD]: '#eab308',
-  [TerrainType.WALL]: '#6b7280',
+  [TerrainType.WALL]: '#57534e',
 };
 
 export const InstancedTerrain = React.memo(({ 
@@ -52,6 +103,7 @@ export const InstancedTerrain = React.memo(({
 }: InstancedTerrainProps) => {
   const meshRefA = useRef<THREE.InstancedMesh>(null);
   const meshRefB = useRef<THREE.InstancedMesh>(null);
+  const topMaterial = useMemo(() => makeTerrainTopMaterial(), []);
 
   const getPos = React.useCallback((x: number, y: number): [number, number, number] => [
     x - map.width / 2 + 0.5,
@@ -121,7 +173,7 @@ export const InstancedTerrain = React.memo(({
       {/* Top surface of tiles */}
       <instancedMesh ref={meshRefB} args={[undefined, undefined, count]} raycast={() => null}>
         <planeGeometry args={[tileSize - 0.02, tileSize - 0.02]} />
-        <meshStandardMaterial />
+        <primitive object={topMaterial} attach="material" />
       </instancedMesh>
     </group>
   );

--- a/apps/web/src/game/UnifiedMap/UnifiedMapLayers.tsx
+++ b/apps/web/src/game/UnifiedMap/UnifiedMapLayers.tsx
@@ -19,6 +19,7 @@ import { TileHoverEffect } from '../ResourceMap/TileHoverEffect';
 import { CombatHighlightsLayer } from './CombatHighlights';
 import { InstancedFoliage } from './InstancedFoliage';
 import { InstancedTerrain } from './InstancedTerrain';
+import { WindGusts } from './WindGusts';
 import { DamagePopup } from './overlays/DamagePopup';
 import { SpellVFX } from './overlays/SpellVFX';
 
@@ -35,7 +36,7 @@ interface TerrainLayerProps {
   wallColor?: string;
 }
 
-export const TerrainLayer = React.memo(({ map, mode, checkerColorA, checkerColorB, sideColor, tileSize, tileRadius, tacticsMode, wallColor }: TerrainLayerProps) => {
+export const TerrainLayer = React.memo(({ map, checkerColorA, checkerColorB, sideColor, tileSize, tileRadius, tacticsMode, wallColor }: TerrainLayerProps) => {
   const decorations = useMemo(() => {
     const result: React.ReactElement[] = [];
 
@@ -59,7 +60,7 @@ export const TerrainLayer = React.memo(({ map, mode, checkerColorA, checkerColor
         } else {
           // Normal mode: skip instanced foliage, only render non-ground decorations
           // All WALL terrain → 3D models (trees or rocks). HERB → bushes. Skip TerrainTile for these.
-          const isInstancedFoliage = terrain !== TerrainType.WALL && (props.combatType === CombatTerrainType.WALL || terrain === TerrainType.HERB);
+          const isInstancedFoliage = props.combatType === CombatTerrainType.WALL || terrain === TerrainType.HERB;
 
           if (!isInstancedFoliage && (props.combatType !== CombatTerrainType.FLAT || props.harvestable)) {
             result.push(
@@ -90,7 +91,8 @@ export const TerrainLayer = React.memo(({ map, mode, checkerColorA, checkerColor
       )}
       {!tacticsMode && (
         <Suspense fallback={null}>
-          <InstancedFoliage map={map} mode={mode} />
+          <InstancedFoliage map={map} />
+          <WindGusts map={map} />
         </Suspense>
       )}
       {decorations}

--- a/apps/web/src/game/UnifiedMap/WindGusts.tsx
+++ b/apps/web/src/game/UnifiedMap/WindGusts.tsx
@@ -1,0 +1,174 @@
+import { useFrame } from '@react-three/fiber';
+import React, { useMemo, useRef } from 'react';
+import * as THREE from 'three';
+
+import type { GameMap } from '@game/shared-types';
+
+import { seededRandom } from './noise';
+
+// Faint 3D wind streaks gliding over the ground — irregular gusts that fade in/out.
+const GUST_COUNT = 10; // number of concurrent streaks
+const GUST_LENGTH = 3.8; // world units along travel direction
+const GUST_WIDTH = 0.35; // width across travel direction
+const GUST_HEIGHT = 0.1; // height of streak above ground
+const GUST_SPEED_MIN = 0.2; // world units / second (each gust picks its own in this range)
+const GUST_SPEED_MAX = 1.5;
+const GUST_OPACITY = 0.15; // peak opacity (very faint)
+const GUST_REST_MAX = 5.0; // max idle seconds between passes (drives irregularity)
+const GUST_AREA_SCALE_LATERAL = 0.7; // lateral (width) coverage as fraction of map diagonal
+const GUST_AREA_SCALE_LENGTH = 0.3;  // travel-axis (length) coverage as fraction of map diagonal
+const GUST_FADE = 0.28;              // fraction of the travel span used for smooth fade in/out
+const GUST_BASE_ANGLE = Math.PI / 6; // base wind angle (radians from +X axis, ~30°)
+const GUST_ANGLE_SPREAD = Math.PI;   // max random angular deviation per combat (π = full rotation)
+
+interface GustState {
+  s: number; // position along travel axis (−half … +half)
+  lateral: number; // sideways offset
+  speed: number;
+  rest: number; // remaining idle seconds before re-entering
+}
+
+function hashMapWind(map: GameMap): number {
+  let h = 2166136261 >>> 0;
+  const mix = (v: number): void => { h = Math.imul(h ^ v, 16777619) >>> 0; };
+  mix(map.width);
+  mix(map.height);
+  for (let y = 0; y < map.height; y++) {
+    const row = map.grid[y];
+    for (let x = 0; x < map.width; x++) {
+      const t = String(row[x]);
+      for (let k = 0; k < t.length; k++) mix(t.charCodeAt(k));
+    }
+  }
+  return (h % 1_000_000) + 1;
+}
+
+function smoothstep(edge0: number, edge1: number, x: number): number {
+  const t = Math.max(0, Math.min(1, (x - edge0) / (edge1 - edge0)));
+  return t * t * (3 - 2 * t);
+}
+
+function makeStreakTexture(): THREE.Texture {
+  const w = 128;
+  const h = 32;
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return new THREE.Texture();
+  const img = ctx.createImageData(w, h);
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      // Soft oval: bright at centre, fading to 0 at both ends and edges.
+      const u = Math.sin((Math.PI * x) / (w - 1));
+      const v = Math.sin((Math.PI * y) / (h - 1));
+      const a = Math.pow(u, 1.5) * Math.pow(v, 1.2);
+      const i = (y * w + x) * 4;
+      img.data[i] = 255;
+      img.data[i + 1] = 255;
+      img.data[i + 2] = 255;
+      img.data[i + 3] = Math.floor(a * 255);
+    }
+  }
+  ctx.putImageData(img, 0, 0);
+  return new THREE.CanvasTexture(canvas);
+}
+
+export const WindGusts = React.memo(({ map }: { map: GameMap }) => {
+  // Per-combat seeded direction: base angle + random offset from map hash.
+  const dir = useMemo(() => {
+    const angle = GUST_BASE_ANGLE + seededRandom(hashMapWind(map) * 1.7) * GUST_ANGLE_SPREAD;
+    return new THREE.Vector2(Math.cos(angle), Math.sin(angle));
+  }, [map]);
+  const texture = useMemo(() => makeStreakTexture(), []);
+
+  // Coverage: lateral and travel-axis each scale independently from map diagonal.
+  const span = Math.hypot(map.width, map.height);
+  const travelHalf = span * GUST_AREA_SCALE_LENGTH / 2 + GUST_LENGTH;
+  const lateralSpread = span * GUST_AREA_SCALE_LATERAL;
+
+  // Fixed orientation: lay the plane flat, then yaw it to align its length with travel dir.
+  const quaternion = useMemo(() => {
+    const flat = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(1, 0, 0), -Math.PI / 2);
+    const yaw = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), Math.atan2(-dir.y, dir.x));
+    return yaw.multiply(flat);
+  }, [dir]);
+
+  const meshRefs = useRef<(THREE.Mesh | null)[]>([]);
+  const materials = useMemo(
+    () =>
+      Array.from({ length: GUST_COUNT }, () =>
+        new THREE.MeshBasicMaterial({
+          map: texture,
+          transparent: true,
+          opacity: 0,
+          depthWrite: false,
+          blending: THREE.AdditiveBlending,
+          side: THREE.DoubleSide,
+        }),
+      ),
+    [texture],
+  );
+
+  const gusts = useRef<GustState[]>(
+    Array.from({ length: GUST_COUNT }, (_, i) => ({
+      s: -travelHalf + seededRandom(i * 7.3) * travelHalf * 2,
+      lateral: (seededRandom(i * 3.1) - 0.5) * lateralSpread,
+      speed: GUST_SPEED_MIN + seededRandom(i * 5.9) * (GUST_SPEED_MAX - GUST_SPEED_MIN),
+      rest: seededRandom(i * 11.7) * GUST_REST_MAX,
+    })),
+  );
+
+  const perp = useMemo(() => new THREE.Vector2(-dir.y, dir.x), [dir]);
+
+  useFrame((_, delta) => {
+    const dt = Math.min(delta, 0.05);
+    for (let i = 0; i < GUST_COUNT; i++) {
+      const g = gusts.current[i];
+      const mesh = meshRefs.current[i];
+      const mat = materials[i];
+      if (!mesh) continue;
+
+      if (g.rest > 0) {
+        g.rest -= dt;
+        mat.opacity = 0;
+        continue;
+      }
+
+      g.s += g.speed * dt;
+      if (g.s > travelHalf) {
+        // Respawn with new randomised pass.
+        g.s = -travelHalf;
+        g.lateral = (Math.random() - 0.5) * lateralSpread;
+        g.speed = GUST_SPEED_MIN + Math.random() * (GUST_SPEED_MAX - GUST_SPEED_MIN);
+        g.rest = Math.random() * GUST_REST_MAX;
+      }
+
+      mesh.position.set(
+        dir.x * g.s + perp.x * g.lateral,
+        GUST_HEIGHT,
+        dir.y * g.s + perp.y * g.lateral,
+      );
+      // Smooth (cubic) fade in at the start and out at the end of the travel span.
+      const progress = (g.s + travelHalf) / (2 * travelHalf);
+      const env = Math.min(smoothstep(0, GUST_FADE, progress), smoothstep(0, GUST_FADE, 1 - progress));
+      mat.opacity = GUST_OPACITY * env;
+    }
+  });
+
+  return (
+    <group>
+      {materials.map((mat, i) => (
+        <mesh
+          key={i}
+          ref={(el) => { meshRefs.current[i] = el; }}
+          quaternion={quaternion}
+          material={mat}
+          raycast={() => null}
+        >
+          <planeGeometry args={[GUST_LENGTH, GUST_WIDTH]} />
+        </mesh>
+      ))}
+    </group>
+  );
+});

--- a/apps/web/src/game/UnifiedMap/foliage.spec.ts
+++ b/apps/web/src/game/UnifiedMap/foliage.spec.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+
+import { TerrainType } from '@game/shared-types';
+
+import type { FoliageData } from './InstancedFoliage';
+import { buildGrass, hashMap, isTileWalkable } from './InstancedFoliage';
+
+// Minimal GameMap builder for tests.
+function makeMap(grid: TerrainType[][]): { width: number; height: number; grid: TerrainType[][]; seedId: string } {
+  return { width: grid[0].length, height: grid.length, grid, seedId: 'FORGE' as unknown as string };
+}
+
+const GROUND = TerrainType.GROUND;
+
+describe('isTileWalkable', () => {
+  const map = makeMap([
+    [GROUND, GROUND],
+    [GROUND, TerrainType.GOLD],
+  ]);
+
+  it('returns true for GROUND', () => {
+    expect(isTileWalkable(map, 0, 0)).toBe(true);
+  });
+
+  it('returns false for HOLE terrain (GOLD)', () => {
+    expect(isTileWalkable(map, 1, 1)).toBe(false);
+  });
+
+  it('returns false out of bounds', () => {
+    expect(isTileWalkable(map, -1, 0)).toBe(false);
+    expect(isTileWalkable(map, 0, 5)).toBe(false);
+    expect(isTileWalkable(map, 99, 0)).toBe(false);
+  });
+});
+
+describe('hashMap', () => {
+  const mapA = makeMap([[GROUND, GROUND], [GROUND, GROUND]]);
+  const mapB = makeMap([[GROUND, TerrainType.HERB], [GROUND, GROUND]]);
+
+  it('returns positive integer', () => {
+    const h = hashMap(mapA);
+    expect(h).toBeGreaterThan(0);
+    expect(Number.isInteger(h)).toBe(true);
+  });
+
+  it('is deterministic', () => {
+    expect(hashMap(mapA)).toBe(hashMap(mapA));
+  });
+
+  it('different maps produce different hashes', () => {
+    expect(hashMap(mapA)).not.toBe(hashMap(mapB));
+  });
+
+  it('maps with swapped dimensions differ', () => {
+    const mapC = makeMap([[GROUND, GROUND, GROUND], [GROUND, GROUND, GROUND]]);
+    const mapD = makeMap([[GROUND, GROUND], [GROUND, GROUND], [GROUND, GROUND]]);
+    expect(hashMap(mapC)).not.toBe(hashMap(mapD));
+  });
+});
+
+describe('buildGrass', () => {
+  const map = makeMap([
+    [GROUND, GROUND, GROUND, GROUND, GROUND],
+    [GROUND, GROUND, GROUND, GROUND, GROUND],
+    [GROUND, GROUND, GROUND, GROUND, GROUND],
+    [GROUND, GROUND, GROUND, GROUND, GROUND],
+    [GROUND, GROUND, GROUND, GROUND, GROUND],
+  ]);
+
+  it('produces blades on a walkable map', () => {
+    const list: FoliageData[] = [];
+    buildGrass(list, map);
+    expect(list.length).toBeGreaterThan(0);
+  });
+
+  it('is deterministic — same map → identical list', () => {
+    const a: FoliageData[] = [];
+    const b: FoliageData[] = [];
+    buildGrass(a, map);
+    buildGrass(b, map);
+    expect(a).toEqual(b);
+  });
+
+  it('different maps → different placement', () => {
+    const map2 = makeMap([
+      [GROUND, GROUND, TerrainType.HERB, GROUND, GROUND],
+      [GROUND, GROUND, GROUND, GROUND, GROUND],
+      [GROUND, GROUND, GROUND, GROUND, GROUND],
+      [GROUND, GROUND, GROUND, GROUND, GROUND],
+      [GROUND, GROUND, GROUND, GROUND, GROUND],
+    ]);
+    const a: FoliageData[] = [];
+    const b: FoliageData[] = [];
+    buildGrass(a, map);
+    buildGrass(b, map2);
+    // Different maps → different first blade (or different count)
+    const aStr = JSON.stringify(a[0]);
+    const bStr = JSON.stringify(b[0]);
+    expect(aStr).not.toBe(bStr);
+  });
+
+  it('all blades placed on walkable tiles', () => {
+    const list: FoliageData[] = [];
+    buildGrass(list, map);
+    for (const blade of list) {
+      expect(isTileWalkable(map, blade.x, blade.y)).toBe(true);
+    }
+  });
+
+  it('blade tile coords are within map bounds', () => {
+    const list: FoliageData[] = [];
+    buildGrass(list, map);
+    for (const blade of list) {
+      expect(blade.x).toBeGreaterThanOrEqual(0);
+      expect(blade.x).toBeLessThan(map.width);
+      expect(blade.y).toBeGreaterThanOrEqual(0);
+      expect(blade.y).toBeLessThan(map.height);
+    }
+  });
+
+  it('produces no blades on all-HOLE map', () => {
+    const holeMap = makeMap([
+      [TerrainType.GOLD, TerrainType.GOLD, TerrainType.GOLD],
+      [TerrainType.GOLD, TerrainType.GOLD, TerrainType.GOLD],
+      [TerrainType.GOLD, TerrainType.GOLD, TerrainType.GOLD],
+    ]);
+    const list: FoliageData[] = [];
+    buildGrass(list, holeMap);
+    expect(list.length).toBe(0);
+  });
+});

--- a/apps/web/src/game/UnifiedMap/noise.spec.ts
+++ b/apps/web/src/game/UnifiedMap/noise.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { fbm, seededRandom, valueNoise } from './noise';
+
+describe('seededRandom', () => {
+  it('returns value in [0, 1)', () => {
+    for (const s of [0, 1, 42, 999, -5]) {
+      const v = seededRandom(s);
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThan(1);
+    }
+  });
+
+  it('is deterministic', () => {
+    expect(seededRandom(42)).toBe(seededRandom(42));
+    expect(seededRandom(0)).toBe(seededRandom(0));
+  });
+
+  it('different seeds produce different values', () => {
+    const vals = [1, 2, 3, 4, 5].map(seededRandom);
+    const unique = new Set(vals);
+    expect(unique.size).toBe(5);
+  });
+});
+
+describe('valueNoise', () => {
+  it('returns value in [0, 1]', () => {
+    for (let x = 0; x < 5; x++) {
+      for (let y = 0; y < 5; y++) {
+        const v = valueNoise(x * 0.7, y * 1.3, 7);
+        expect(v).toBeGreaterThanOrEqual(0);
+        expect(v).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  it('is deterministic', () => {
+    expect(valueNoise(1.5, 2.5, 7)).toBe(valueNoise(1.5, 2.5, 7));
+  });
+
+  it('interpolates: integer coords equal corner hash', () => {
+    // At integer coords the interpolation collapses to a single hash.
+    const v0 = valueNoise(0, 0, 7);
+    const v1 = valueNoise(1, 0, 7);
+    expect(v0).not.toBe(v1);
+  });
+});
+
+describe('fbm', () => {
+  it('returns value in [0, ~0.94]', () => {
+    let min = Infinity;
+    let max = -Infinity;
+    for (let i = 0; i < 200; i++) {
+      const v = fbm(i * 0.13, i * 0.07, 1337);
+      if (v < min) min = v;
+      if (v > max) max = v;
+    }
+    expect(min).toBeGreaterThanOrEqual(0);
+    expect(max).toBeLessThanOrEqual(1);
+  });
+
+  it('is deterministic', () => {
+    expect(fbm(3.14, 2.71, 42)).toBe(fbm(3.14, 2.71, 42));
+  });
+
+  it('different seeds shift output', () => {
+    const a = fbm(1, 1, 0);
+    const b = fbm(1, 1, 100);
+    expect(a).not.toBe(b);
+  });
+});

--- a/apps/web/src/game/UnifiedMap/noise.ts
+++ b/apps/web/src/game/UnifiedMap/noise.ts
@@ -1,0 +1,38 @@
+export function seededRandom(seed: number): number {
+  const x = Math.sin(seed + 1) * 43758.5453123;
+  return x - Math.floor(x);
+}
+
+function hash2(ix: number, iy: number, seed: number): number {
+  const x = Math.sin(ix * 127.1 + iy * 311.7 + seed * 74.7) * 43758.5453123;
+  return x - Math.floor(x);
+}
+
+function smooth(t: number): number {
+  return t * t * (3 - 2 * t);
+}
+
+export function valueNoise(x: number, y: number, seed: number): number {
+  const ix = Math.floor(x);
+  const iy = Math.floor(y);
+  const ux = smooth(x - ix);
+  const uy = smooth(y - iy);
+  const a = hash2(ix, iy, seed);
+  const b = hash2(ix + 1, iy, seed);
+  const c = hash2(ix, iy + 1, seed);
+  const d = hash2(ix + 1, iy + 1, seed);
+  return a * (1 - ux) * (1 - uy) + b * ux * (1 - uy) + c * (1 - ux) * uy + d * ux * uy;
+}
+
+// Fractal Brownian motion: 4 octaves → natural, blotchy field in [0, ~0.94].
+export function fbm(x: number, y: number, seed: number): number {
+  let amp = 0.5;
+  let freq = 1;
+  let sum = 0;
+  for (let o = 0; o < 4; o++) {
+    sum += amp * valueNoise(x * freq, y * freq, seed + o * 13);
+    freq *= 2;
+    amp *= 0.5;
+  }
+  return sum;
+}


### PR DESCRIPTION
Rebuilt cleanly on top of dev (branch history had diverged onto a stale base). Net change is scoped to the UnifiedMap foliage/terrain layer:

- noise.ts: shared seeded value-noise / FBM helpers (+ specs)
- InstancedFoliage: per-map seeded star-shaped grass clumps in tile joints, baked green-mask leaf wind, transparency controls (+ specs)
- InstancedTerrain: procedural world-space terrain grain texture
- WindGusts: faint additive 3D wind streaks, per-combat seeded direction, individual gust speed, smoothstep fade in/out
- UnifiedMapLayers: wire WindGusts alongside InstancedFoliage

Preserves dev infrastructure: assetUrl() model wrapping, TerrainLayer mode prop, TerrainType.WALL.